### PR TITLE
refactor: styling system cleanup

### DIFF
--- a/apps/web/src/app/brand-side/page.tsx
+++ b/apps/web/src/app/brand-side/page.tsx
@@ -47,6 +47,7 @@ export default function TestCardPage() {
       cap: "#1e3a8a",
       gloves: "#1e3a8a",
       pads: "#1e3a8a",
+      shoes: "#1e3a8a",
       bat: "#fbbf24",
       capAccent: "#ef4444",
     },
@@ -55,6 +56,7 @@ export default function TestCardPage() {
       cap: "#f43f5e",
       gloves: "#10b981",
       pads: "#f59e0b",
+      shoes: "#06b6d4",
       bat: "#8b5cf6",
       capAccent: "#ffffff",
     },
@@ -63,6 +65,7 @@ export default function TestCardPage() {
       cap: "#18181b",
       gloves: "#18181b",
       pads: "#18181b",
+      shoes: "#18181b",
       bat: "#ffffff",
       capAccent: "#3b82f6",
     },
@@ -71,6 +74,7 @@ export default function TestCardPage() {
       cap: "#ea580c",
       gloves: "#ea580c",
       pads: "#ea580c",
+      shoes: "#ea580c",
       bat: "#fde047",
       capAccent: "#fde047",
     },
@@ -98,7 +102,7 @@ export default function TestCardPage() {
   );
 
   return (
-    <main className="min-h-screen bg-[#0d0d0d] flex flex-row items-center justify-center p-12 gap-16 overflow-x-auto">
+    <main className="min-h-screen bg-zinc-950 flex flex-row items-center justify-center p-12 gap-16 overflow-x-auto">
       {/* 1. Main Preview */}
       <section className="flex-shrink-0 flex flex-col items-center gap-6">
         <div className="text-center mb-8">
@@ -174,7 +178,7 @@ export default function TestCardPage() {
                   </span>
                   <input
                     type="color"
-                    value={(currentColors as any)[part] || "#3b82f6"}
+                    value={currentColors[part as keyof CharacterColors] || "#3b82f6"}
                     onInput={(e) =>
                       updateColor(part as keyof CharacterColors, (e.target as HTMLInputElement).value)
                     }
@@ -200,7 +204,7 @@ export default function TestCardPage() {
                   </span>
                   <input
                     type="color"
-                    value={(currentColors as any)[part] || "#fbbf24"}
+                    value={currentColors[part as keyof CharacterColors] || "#fbbf24"}
                     onInput={(e) =>
                       updateColor(part as keyof CharacterColors, (e.target as HTMLInputElement).value)
                     }
@@ -231,7 +235,7 @@ export default function TestCardPage() {
                       cap: p.cap,
                       gloves: p.gloves,
                       pads: p.pads,
-                      shoes: p.pads,
+                      shoes: p.shoes,
                       bat: p.bat,
                       capAccent: p.capAccent,
                     },

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -81,38 +81,3 @@
   }
 }
 
-@keyframes card-flip {
-  0% {
-    transform: rotateY(0deg);
-  }
-  50% {
-    transform: rotateY(90deg);
-  }
-  100% {
-    transform: rotateY(0deg);
-  }
-}
-
-@keyframes pack-reveal {
-  0% {
-    transform: scale(0.8) translateY(20px);
-    opacity: 0;
-  }
-  60% {
-    transform: scale(1.05) translateY(-5px);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1) translateY(0);
-    opacity: 1;
-  }
-}
-
-@keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 8px var(--gold), 0 0 16px var(--gold);
-  }
-  50% {
-    box-shadow: 0 0 16px var(--gold), 0 0 32px var(--gold), 0 0 48px rgba(244, 162, 97, 0.3);
-  }
-}

--- a/apps/web/src/components/card/BrandCard.tsx
+++ b/apps/web/src/components/card/BrandCard.tsx
@@ -32,7 +32,7 @@ export const BrandCard: React.FC<BrandCardProps> = ({
   return (
     <div className="relative w-[750px] h-[1050px] overflow-hidden bg-white select-none">
       {/* 1. Base Texture */}
-      <div className="absolute inset-0 opacity-[0.15] bg-retro-grain pointer-events-none" />
+      <div className="absolute inset-0 opacity-[0.25] bg-retro-grain pointer-events-none" />
 
       {/* 2. Style Accents: Concentric Ring Accents */}
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none">

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -14,6 +14,7 @@ const config: Config = {
         display: ["'Bebas Neue'", 'cursive'],
         body: ["'Inter'", 'sans-serif'],
         supermercado: ['var(--font-supermercado)', 'cursive'],
+        'roboto-mono': ['var(--font-roboto-mono)', 'monospace'],
       },
       boxShadow: {
         card: '0 4px 24px rgba(0,0,0,0.4)',


### PR DESCRIPTION
## Summary

- Removed dead keyframes (`card-flip`, `pack-reveal`, `pulse-glow`) from `globals.css` — `shimmer` and `foil-shift` untouched
- Fixed preset bug in brand-side page: `shoes` was always copying `pads` colour — each preset now has its own correct shoe colour
- Replaced `bg-[#0d0d0d]` with `bg-zinc-950` (no custom dark token exists in config)
- Removed `(currentColors as any)[part]` type cast — replaced with `currentColors[part as keyof CharacterColors]`
- Raised retro-grain texture opacity from `0.15` → `0.25` in `BrandCard`
- Added `roboto-mono` font family token to `tailwind.config.ts` for use in `StatCard`

## Test plan

- [ ] `/brand-side` loads and renders correctly
- [ ] Style presets apply correct shoe colours independently of pads
- [ ] Grain texture visibly stronger on the brand card
- [ ] No TypeScript errors (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)