### PR TITLE
fix: restore lint CI — migrate to ESLint 9 flat config

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,0 +1,3 @@
+import nextConfig from "eslint-config-next";
+
+export default [...nextConfig];

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    turbopack: {
+      root: __dirname,
+    },
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint src",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -71,6 +71,7 @@ export default function CollectionPage() {
           </a>
         </div>
       </div>
+      </main>
     </MobileContainer>
   )
 }


### PR DESCRIPTION
## Summary

- `next lint` was removed in Next.js 16; the CLI was treating `lint` as a directory argument, causing CI to fail with "Invalid project directory"
- Added `eslint.config.mjs` using `eslint-config-next`'s native ESLint 9 flat config export
- Updated lint script from `next lint` → `eslint src`
- Fixed unclosed `<main>` tag in `collection/page.tsx` — caught immediately by the now-working linter
- Added `turbopack.root` in `next.config.mjs` to suppress the multiple-lockfiles workspace warning

## Test plan

- [ ] CI lint step passes on this PR
- [ ] `npm run lint` exits 0 locally
- [ ] No regressions in `npm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)