### PR TITLE
feat: spring scale + blur pose transition

### DIFF
--- a/apps/web/src/components/card/LayeredCharacter.tsx
+++ b/apps/web/src/components/card/LayeredCharacter.tsx
@@ -80,10 +80,14 @@ export const LayeredCharacter: React.FC<LayeredCharacterProps> = ({
         <motion.div
           key={sources.base}
           className="absolute inset-0"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.3, ease: "easeInOut" }}
+          initial={{ opacity: 0, scale: 0.75, filter: "blur(8px)" }}
+          animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+          exit={{ opacity: 0, scale: 1.15, filter: "blur(12px)" }}
+          transition={{
+            opacity: { duration: 0.25, ease: "easeInOut" },
+            scale: { type: "spring", stiffness: 300, damping: 22 },
+            filter: { duration: 0.25, ease: "easeInOut" },
+          }}
         >
           <motion.div className="relative w-full h-full" {...activeMotion}>
             {/* Base layer — rendered as a normal image, no tint */}


### PR DESCRIPTION
## Summary

- Replaces the flat opacity fade on pose switches with a scale + blur transition
- Exit: character scales up to 1.15× and blurs out (12px)
- Enter: character springs in from 0.75× scale with blur clearing — `stiffness: 300, damping: 22`
- Only `LayeredCharacter.tsx` touched — one `motion.div` block changed

## Test plan
- [ ] Switch poses on `/brand-side` and verify spring-in / blur-out feel
- [ ] Tune `stiffness`/`damping` if spring feels too bouncy or too stiff

🤖 Generated with [Claude Code](https://claude.com/claude-code)