### PR TITLE
feat: players listing + detail pages with StatsGrid

### DIFF
--- a/apps/web/public/images/card/player-placeholder.svg
+++ b/apps/web/public/images/card/player-placeholder.svg
@@ -1,0 +1,52 @@
+<svg width="100%" viewBox="0 0 700 420" role="img" xmlns="http://www.w3.org/2000/svg">
+  <title>Player photo placeholder</title>
+  <desc>Placeholder shown when a player photo is unavailable</desc>
+  <defs>
+    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0L0 0L0 40" fill="none" stroke="#e8257a" stroke-width="0.3" opacity="0.2"/>
+    </pattern>
+    <pattern id="dots" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+      <circle cx="10" cy="10" r="1" fill="#ffd600" opacity="0.15"/>
+    </pattern>
+    <clipPath id="card">
+      <rect x="0" y="0" width="700" height="420"/>
+    </clipPath>
+  </defs>
+  <rect x="0" y="0" width="700" height="420" fill="#0a1628"/>
+  <rect x="0" y="0" width="700" height="420" fill="url(#grid)"/>
+  <rect x="0" y="0" width="700" height="420" fill="url(#dots)"/>
+  <ellipse cx="350" cy="520" rx="500" ry="280" fill="#1a3a8a" opacity="0.25"/>
+  <ellipse cx="350" cy="480" rx="320" ry="180" fill="#e8257a" opacity="0.07"/>
+  <rect x="324" y="340" width="52" height="12" rx="2" fill="#ffd600" opacity="0.6"/>
+  <rect x="336" y="316" width="8" height="28" rx="2" fill="#ffd600" opacity="0.5"/>
+  <rect x="356" y="316" width="8" height="28" rx="2" fill="#ffd600" opacity="0.5"/>
+  <rect x="346" y="308" width="8" height="36" rx="2" fill="#ffd600" opacity="0.5"/>
+  <g clip-path="url(#card)">
+    <circle cx="350" cy="148" r="44" fill="#1e3a8a"/>
+    <ellipse cx="350" cy="148" rx="28" ry="32" fill="#c8956a"/>
+    <ellipse cx="350" cy="130" rx="22" ry="14" fill="#1e3a8a"/>
+    <rect x="328" y="124" width="44" height="10" rx="2" fill="#1e3a8a"/>
+    <ellipse cx="350" cy="118" rx="26" ry="8" fill="#1e3a8a"/>
+    <rect x="294" y="192" width="112" height="116" rx="18" fill="#1e3a8a"/>
+    <rect x="236" y="198" width="58" height="80" rx="16" fill="#1e3a8a"/>
+    <ellipse cx="252" cy="198" rx="22" ry="14" fill="#c8956a"/>
+    <rect x="230" y="184" width="44" height="20" rx="6" fill="#c8956a"/>
+    <rect x="228" y="270" width="66" height="14" rx="6" fill="#e8257a" opacity="0.8"/>
+    <rect x="406" y="198" width="58" height="80" rx="16" fill="#1e3a8a"/>
+    <ellipse cx="448" cy="198" rx="22" ry="14" fill="#c8956a"/>
+    <rect x="426" y="184" width="44" height="20" rx="6" fill="#c8956a"/>
+    <rect x="406" y="270" width="66" height="14" rx="6" fill="#e8257a" opacity="0.8"/>
+    <rect x="440" y="176" width="10" height="80" rx="4" fill="#c8956a" transform="rotate(18 445 216)"/>
+    <ellipse cx="453" cy="170" rx="8" ry="12" fill="#a07040" transform="rotate(18 445 216)"/>
+    <rect x="306" y="308" width="38" height="90" rx="12" fill="#1e3a8a"/>
+    <rect x="356" y="308" width="38" height="90" rx="12" fill="#1e3a8a"/>
+    <rect x="308" y="308" width="34" height="54" rx="8" fill="#c8956a"/>
+    <rect x="358" y="308" width="34" height="54" rx="8" fill="#c8956a"/>
+    <rect x="302" y="390" width="48" height="14" rx="7" fill="#e8257a" opacity="0.85"/>
+    <rect x="350" y="390" width="48" height="14" rx="7" fill="#e8257a" opacity="0.85"/>
+  </g>
+  <rect x="0" y="380" width="700" height="40" fill="#0a1628" opacity="0.7"/>
+  <text x="350" y="406" text-anchor="middle" font-family="'Barlow Condensed', 'Arial Narrow', sans-serif" font-size="13" font-weight="700" letter-spacing="8" fill="#ffd600" opacity="0.45">NO PHOTO AVAILABLE</text>
+  <rect x="0" y="0" width="700" height="420" fill="none" stroke="#e8257a" stroke-width="2" opacity="0.3"/>
+  <rect x="6" y="6" width="688" height="408" fill="none" stroke="#ffd600" stroke-width="0.5" opacity="0.15"/>
+</svg>

--- a/apps/web/src/app/players/CountrySelect.tsx
+++ b/apps/web/src/app/players/CountrySelect.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+
+interface CountrySelectProps {
+  countries: string[]
+  selected: string | undefined
+}
+
+export function CountrySelect({ countries, selected }: CountrySelectProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const params = new URLSearchParams(searchParams.toString())
+    if (e.target.value) {
+      params.set('country', e.target.value)
+    } else {
+      params.delete('country')
+    }
+    router.push(`/players?${params.toString()}`)
+  }
+
+  return (
+    <select
+      value={selected ?? ''}
+      onChange={handleChange}
+      className="bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg px-3 py-2 text-xs uppercase tracking-wider cursor-pointer focus:outline-none focus:border-zinc-500"
+    >
+      <option value="">All Countries</option>
+      {countries.map((c) => (
+        <option key={c} value={c}>
+          {c}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -1,0 +1,122 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchPlayerById } from "@/lib/queries/players";
+import { playerToStatCard } from "@/lib/adapters/playerToStatCard";
+import StatCard from "@/components/card/StatCard";
+import { BrandCard } from "@/components/card/BrandCard";
+import { CardWrapper } from "@/components/card/CardWrapper";
+import { StatsGrid } from "@/components/card/StatsGrid";
+import { POSE_REGISTRY } from "@/constants/poses";
+
+type Params = Promise<{ id: string }>;
+type SearchParams = Promise<{ view?: string }>;
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+const ALPHA_POSE = POSE_REGISTRY.find((p) => p.label === "Alpha Shot")!;
+
+export default async function PlayerDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: SearchParams;
+}) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const view = sp.view ?? "card";
+
+  const result = await fetchPlayerById(id);
+
+  if (result.error) {
+    if (result.error.code === "PGRST116") notFound();
+    return (
+      <main className="min-h-screen bg-zinc-950 flex items-center justify-center p-8">
+        <p className="text-red-400 text-sm">{result.error.message}</p>
+      </main>
+    );
+  }
+
+  const { player } = result.data;
+  const playerStats = playerToStatCard(
+    result.data,
+    player.external_id,
+    "Legend",
+  );
+  return (
+    <main className="bg-zinc-950 min-h-screen">
+      {/* Top bar */}
+      <div className="px-8 pt-8 flex items-center gap-6">
+        <Link
+          href="/players"
+          className="text-zinc-500 hover:text-zinc-300 text-sm font-mono tracking-wider transition-colors flex-shrink-0"
+        >
+          ← Players
+        </Link>
+        <div className="flex items-center gap-4 flex-1 justify-center">
+          <h1 className="font-display text-4xl text-cream leading-none">
+            {player.name}
+          </h1>
+          <span className="text-zinc-500 text-xs uppercase tracking-wider font-mono mt-1">
+            {player.country}
+          </span>
+          <span className="text-zinc-500 text-xs uppercase tracking-wider font-mono mt-1">
+            {player.role}
+          </span>
+        </div>
+        <div className="flex-shrink-0 w-20" />
+      </div>
+
+      <div className="px-8 py-8">
+        {/* View tabs */}
+        <div className="flex gap-2 mb-8 justify-center mt-6">
+          {(["card", "table"] as const).map((v) => (
+            <Link
+              key={v}
+              href={`/players/${player.id}?view=${v}`}
+              className={`px-5 py-2 rounded-full text-xs uppercase tracking-wider font-medium transition-colors ${
+                view === v
+                  ? "bg-zinc-100 text-zinc-950"
+                  : "text-zinc-500 border border-zinc-800 hover:border-zinc-600"
+              }`}
+            >
+              {v === "card" ? "Card View" : "Table View"}
+            </Link>
+          ))}
+        </div>
+
+        {/* Content */}
+        {view === "card" ? (
+          <div className="flex flex-wrap gap-8 justify-center">
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-zinc-600 text-[10px] uppercase tracking-widest font-mono">
+                Stat Card
+              </p>
+              <CardWrapper scale={0.5}>
+                <StatCard stats={playerStats} />
+              </CardWrapper>
+            </div>
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-zinc-600 text-[10px] uppercase tracking-widest font-mono">
+                Brand Card
+              </p>
+              <CardWrapper scale={0.5}>
+                <BrandCard
+                  layers={ALPHA_POSE.layers}
+                  width={ALPHA_POSE.width}
+                  height={ALPHA_POSE.height}
+                />
+              </CardWrapper>
+            </div>
+          </div>
+        ) : (
+          <div className="max-w-3xl mx-auto">
+            <div className="rounded-2xl overflow-hidden border border-zinc-800">
+              <StatsGrid stats={playerStats} theme="dark" />
+            </div>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,0 +1,221 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { fetchPlayersWithFormatStats, fetchCountries } from '@/lib/queries/players'
+import type { PlayerWithFormatFilter } from '@/lib/queries/types'
+import type { PlayerRole, PlayerRow, PlayerStatsRow } from '@/types/database.types'
+import { CountrySelect } from './CountrySelect'
+
+type SearchParams = Promise<{
+  country?: string
+  role?: string
+  search?: string
+}>
+
+const ROLES: { label: string; value: PlayerRole | undefined }[] = [
+  { label: 'All', value: undefined },
+  { label: 'Batter', value: 'batter' },
+  { label: 'Bowler', value: 'bowler' },
+  { label: 'Allrounder', value: 'allrounder' },
+  { label: 'Keeper', value: 'keeper' },
+]
+
+function buildUrl(p: {
+  country?: string
+  role?: PlayerRole
+  search?: string
+}): string {
+  const params = new URLSearchParams()
+  if (p.country) params.set('country', p.country)
+  if (p.role) params.set('role', p.role)
+  if (p.search) params.set('search', p.search)
+  const qs = params.toString()
+  return qs ? `/players?${qs}` : '/players'
+}
+
+function initials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+}
+
+function HeadlineStat({
+  player,
+  stats,
+}: {
+  player: PlayerRow
+  stats: PlayerStatsRow | null
+}) {
+  const showBowling = player.role === 'bowler' || player.role === 'allrounder'
+  const val = showBowling ? (stats?.bowl_wickets ?? '-') : (stats?.bat_runs ?? '-')
+  const unit = showBowling ? 'wkts' : 'runs'
+
+  return (
+    <div className="font-display text-2xl text-brand">
+      {val} <span className="text-xs text-zinc-500 font-sans">{unit}</span>
+    </div>
+  )
+}
+
+const pillBase = 'px-3 py-1 rounded-full text-xs uppercase tracking-wider font-medium transition-colors'
+const pillActive = 'bg-brand text-white'
+const pillInactive = 'bg-zinc-900 text-zinc-500 border border-zinc-800 hover:border-zinc-600 hover:text-zinc-300'
+
+export default async function PlayersPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const country = params.country || undefined
+  const role = (params.role as PlayerRole | undefined) || undefined
+  const search = params.search || undefined
+
+  const filter: PlayerWithFormatFilter = { country, role, search }
+
+  const [playersResult, countriesResult] = await Promise.all([
+    fetchPlayersWithFormatStats(filter),
+    fetchCountries(),
+  ])
+
+  if (playersResult.error) {
+    return (
+      <main className="min-h-screen bg-zinc-950 flex items-center justify-center">
+        <p className="text-red-400">{playersResult.error.message}</p>
+      </main>
+    )
+  }
+
+  const players = playersResult.data
+  const countries = countriesResult.data ?? []
+
+  const clearSearchUrl = buildUrl({ country, role })
+
+  return (
+    <main className="bg-zinc-950 min-h-screen p-12">
+      {/* Heading */}
+      <h1 className="font-display text-5xl text-cream tracking-widest uppercase mb-2">
+        Players
+      </h1>
+      <p className="text-zinc-600 text-xs uppercase tracking-widest font-mono mb-8">
+        Nostalgia Cricket Card · 1990s Legends
+      </p>
+
+      {/* Search form */}
+      <form method="GET" action="/players" className="flex items-center gap-3 mb-6">
+        {country && <input type="hidden" name="country" value={country} />}
+        {role && <input type="hidden" name="role" value={role} />}
+        <input
+          type="text"
+          name="search"
+          defaultValue={search ?? ''}
+          placeholder="Search players…"
+          className="bg-zinc-900 border border-zinc-800 text-zinc-200 rounded-xl px-4 py-2 text-sm w-64 focus:border-zinc-600 outline-none"
+        />
+        <button
+          type="submit"
+          className="bg-zinc-800 text-zinc-200 px-4 py-2 rounded-xl text-sm hover:bg-zinc-700 transition-colors"
+        >
+          Search
+        </button>
+        {search && (
+          <Link
+            href={clearSearchUrl}
+            className="bg-zinc-900 border border-zinc-800 text-zinc-400 px-3 py-2 rounded-xl text-sm hover:text-zinc-200 transition-colors"
+          >
+            ×
+          </Link>
+        )}
+      </form>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap gap-3 items-center mb-6">
+        {/* Country select */}
+        {countries.length > 0 && (
+          <Suspense fallback={
+            <select className="bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg px-3 py-2 text-xs uppercase tracking-wider">
+              <option>All Countries</option>
+            </select>
+          }>
+            <CountrySelect countries={countries} selected={country} />
+          </Suspense>
+        )}
+
+        {/* Role pills */}
+        <div className="flex gap-2 flex-wrap">
+          {ROLES.map(({ label, value }) => (
+            <Link
+              key={label}
+              href={buildUrl({ country, role: value, search })}
+              className={`${pillBase} ${role === value ? pillActive : pillInactive}`}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* Result count */}
+      <p className="text-zinc-600 text-xs font-mono mb-2">
+        Showing {players.length} player{players.length !== 1 ? 's' : ''}
+        {search && <span> for &ldquo;{search}&rdquo;</span>}
+      </p>
+
+      {/* Grid */}
+      {players.length === 0 ? (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mt-8">
+          <div className="col-span-4 text-zinc-600 text-center py-24 flex flex-col items-center gap-4">
+            <p>No players found.</p>
+            <Link
+              href="/players"
+              className="text-xs uppercase tracking-wider border border-zinc-800 px-4 py-2 rounded-full hover:border-zinc-600 hover:text-zinc-400 transition-colors"
+            >
+              Reset filters
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mt-8">
+          {players.map(({ player, stats }) => (
+            <Link
+              key={player.id}
+              href={`/players/${player.id}`}
+              className="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden hover:border-zinc-600 transition-all hover:scale-[1.02]"
+            >
+              {/* Photo */}
+              <div className="relative h-48 w-full bg-zinc-800">
+                <Image
+                  src={player.photo_url ?? '/images/card/player-placeholder.svg'}
+                  alt={player.name}
+                  fill
+                  sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                  className="object-cover"
+                  unoptimized
+                />
+              </div>
+
+              {/* Info */}
+              <div className="p-4 flex flex-col gap-2">
+                <p className="font-display text-xl text-cream tracking-wide leading-tight">
+                  {player.name}
+                </p>
+                <div className="flex gap-1 flex-wrap">
+                  <span className="px-2 py-0.5 bg-zinc-800 text-zinc-400 text-[10px] uppercase tracking-wider rounded-full">
+                    {player.country}
+                  </span>
+                  <span className="px-2 py-0.5 bg-zinc-800 text-zinc-400 text-[10px] uppercase tracking-wider rounded-full capitalize">
+                    {player.role}
+                  </span>
+                </div>
+                <HeadlineStat player={player} stats={stats} />
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/apps/web/src/components/card/BrandCard.tsx
+++ b/apps/web/src/components/card/BrandCard.tsx
@@ -5,8 +5,10 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import { CharacterColors, LayeredCharacter, LayeredCharacterSources } from "./LayeredCharacter";
 
+type PartialCharacterColors = Partial<CharacterColors>
+
 interface BrandCardProps {
-  colors?: CharacterColors;
+  colors?: PartialCharacterColors;
   layers: LayeredCharacterSources;
   width?: number;
   height?: number;
@@ -17,14 +19,7 @@ interface BrandCardProps {
  * Dimensions: 750x1050px
  */
 export const BrandCard: React.FC<BrandCardProps> = ({
-  colors = {
-    cap: "#3b82f6",
-    capAccent: "#fbbf24",
-    gloves: "#3b82f6",
-    pads: "#3b82f6",
-    shoes: "#3b82f6",
-    bat: "#fbbf24",
-  },
+  colors = {},
   layers,
   width = 500,
   height = 425,

--- a/apps/web/src/components/card/LayeredCharacter.tsx
+++ b/apps/web/src/components/card/LayeredCharacter.tsx
@@ -30,7 +30,7 @@ export interface LayeredCharacterSources {
 
 interface LayeredCharacterProps {
   sources: LayeredCharacterSources;
-  colors: CharacterColors;
+  colors: Partial<CharacterColors>;
   /** Visual width in the unscaled 750×1050 coordinate space. */
   width?: number;
   /** Visual height in the unscaled 750×1050 coordinate space. */
@@ -62,17 +62,17 @@ export const LayeredCharacter: React.FC<LayeredCharacterProps> = ({
 }) => {
   const activeMotion = motionProps ?? defaultMotion;
 
-  const coloredLayers: Array<{ src: string; color: string }> = [];
+  const coloredLayers: Array<{ src: string; color: string | undefined }> = [];
 
   if (sources.cap) coloredLayers.push({ src: sources.cap, color: colors.cap });
   if (sources.capAccent) coloredLayers.push({ src: sources.capAccent, color: colors.capAccent });
   if (sources.gloves) coloredLayers.push({ src: sources.gloves, color: colors.gloves });
   if (sources.pads) coloredLayers.push({ src: sources.pads, color: colors.pads });
   if (sources.shoes) coloredLayers.push({ src: sources.shoes, color: colors.shoes });
-  if (sources.bat && colors.bat) coloredLayers.push({ src: sources.bat, color: colors.bat });
-  if (sources.batOutline && colors.bat) coloredLayers.push({ src: sources.batOutline, color: colors.bat });
-  if (sources.ball && colors.ball) coloredLayers.push({ src: sources.ball, color: colors.ball });
-  if (sources.wickets && colors.wickets) coloredLayers.push({ src: sources.wickets, color: colors.wickets });
+  if (sources.bat) coloredLayers.push({ src: sources.bat, color: colors.bat });
+  if (sources.batOutline) coloredLayers.push({ src: sources.batOutline, color: colors.bat });
+  if (sources.ball) coloredLayers.push({ src: sources.ball, color: colors.ball });
+  if (sources.wickets) coloredLayers.push({ src: sources.wickets, color: colors.wickets });
 
   return (
     <div className={`relative ${className}`} style={{ width, height }}>
@@ -117,21 +117,23 @@ export const LayeredCharacter: React.FC<LayeredCharacterProps> = ({
                   alt=""
                   className="absolute inset-0 w-full h-full object-contain select-none"
                 />
-                <div
-                  className="absolute inset-0"
-                  style={{
-                    backgroundColor: color,
-                    mixBlendMode: "color",
-                    WebkitMaskImage: `url(${src})`,
-                    maskImage: `url(${src})`,
-                    WebkitMaskSize: "contain",
-                    maskSize: "contain",
-                    WebkitMaskRepeat: "no-repeat",
-                    maskRepeat: "no-repeat",
-                    WebkitMaskPosition: "center",
-                    maskPosition: "center",
-                  }}
-                />
+                {color && (
+                  <div
+                    className="absolute inset-0"
+                    style={{
+                      backgroundColor: color,
+                      mixBlendMode: "color",
+                      WebkitMaskImage: `url(${src})`,
+                      maskImage: `url(${src})`,
+                      WebkitMaskSize: "contain",
+                      maskSize: "contain",
+                      WebkitMaskRepeat: "no-repeat",
+                      maskRepeat: "no-repeat",
+                      WebkitMaskPosition: "center",
+                      maskPosition: "center",
+                    }}
+                  />
+                )}
               </div>
             ))}
           </motion.div>

--- a/apps/web/src/components/card/StatCard.tsx
+++ b/apps/web/src/components/card/StatCard.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import styles from './StatCard.module.css'
+import { StatsGrid } from './StatsGrid'
 
 export interface StatValue {
   test: string | number
@@ -70,103 +71,7 @@ export default function StatCard({ stats }: { stats: PlayerStats }) {
       {/* MIDDLE ZONE */}
       <div className={styles.middleZone}></div>
 
-      {/* STATS AREA */}
-      <div className={styles.statsArea}>
-        {/* FORMAT HEADER */}
-        <div className={styles.fmtRow}>
-          <div className={styles.fmtEmpty}></div>
-          <div className={`${styles.fmtBubble} ${styles.fmtBubbleTest}`}>
-            <div className={styles.fmtNameSide}>Test</div>
-            <div className={styles.fmtCountSide}>{stats.matches.test}</div>
-          </div>
-          <div className={`${styles.fmtBubble} ${styles.fmtBubbleOdi}`}>
-            <div className={styles.fmtNameSide}>ODI</div>
-            <div className={styles.fmtCountSide}>{stats.matches.odi}</div>
-          </div>
-          <div className={`${styles.fmtBubble} ${styles.fmtBubbleT20}`}>
-            <div className={styles.fmtNameSide}>T20I</div>
-            <div className={styles.fmtCountSide}>{stats.matches.t20i}</div>
-          </div>
-        </div>
-
-        {/* BATTING */}
-        <div className={`${styles.section} ${styles.secBat}`}>
-          <StatRow label="Runs" values={stats.batting.runs} labelClass={styles.batLbl} />
-          <StatRow label="Not Outs" values={stats.batting.notOuts} labelClass={styles.batLbl} />
-          <StatRow label="High Score" values={stats.batting.highScore} labelClass={styles.batLbl} />
-          <StatRow label="Bat. Avg" values={stats.batting.avg} labelClass={styles.batLbl} />
-          
-          {/* 50s / 100s */}
-          <div className={styles.splitRow}>
-            <div className={styles.splitLabel}>
-              <div className={styles.splitLblL}>50s</div>
-              <div className={styles.splitLblR}>100s</div>
-            </div>
-            <SplitPill val1={stats.batting.halfCenturies.test} val2={stats.batting.centuries.test} mode="test" />
-            <SplitPill val1={stats.batting.halfCenturies.odi} val2={stats.batting.centuries.odi} mode="odi" />
-            <SplitPill val1={stats.batting.halfCenturies.t20i} val2={stats.batting.centuries.t20i} mode="t20i" />
-          </div>
-
-          {/* 4s / 6s */}
-          <div className={styles.splitRow}>
-            <div className={styles.splitLabel}>
-              <div className={styles.splitLblL}>4s</div>
-              <div className={styles.splitLblR}>6s</div>
-            </div>
-            <SplitPill val1={stats.batting.fours.test} val2={stats.batting.sixes.test} mode="test" />
-            <SplitPill val1={stats.batting.fours.odi} val2={stats.batting.sixes.odi} mode="odi" />
-            <SplitPill val1={stats.batting.fours.t20i} val2={stats.batting.sixes.t20i} mode="t20i" />
-          </div>
-        </div>
-
-        {/* BOWLING */}
-        <div className={`${styles.section} ${styles.secBwl}`}>
-          <StatRow label="Wickets" values={stats.bowling.wickets} labelClass={styles.bwlLbl} />
-          <StatRow label="Best Bowl" values={stats.bowling.bestBowl} labelClass={styles.bwlLbl} />
-          <StatRow label="Bowl Avg" values={stats.bowling.avg} labelClass={styles.bwlLbl} />
-          <StatRow label="Economy" values={stats.bowling.economy} labelClass={styles.bwlLbl} />
-          
-          {/* 4W / 5W */}
-          <div className={styles.splitRow}>
-            <div className={styles.splitLabel}>
-              <div className={styles.splitLblBwlL}>4W</div>
-              <div className={styles.splitLblBwlR}>5W</div>
-            </div>
-            <SplitPill val1={stats.bowling.fourWkts.test} val2={stats.bowling.fiveWkts.test} mode="test" />
-            <SplitPill val1={stats.bowling.fourWkts.odi} val2={stats.bowling.fiveWkts.odi} mode="odi" />
-            <SplitPill val1={stats.bowling.fourWkts.t20i} val2={stats.bowling.fiveWkts.t20i} mode="t20i" />
-          </div>
-        </div>
-
-        {/* FIELDING */}
-        <div className={`${styles.section} ${styles.secFld}`}>
-          <StatRow label="Catches" values={stats.fielding.catches} labelClass={styles.fldLbl} />
-          <StatRow label="Run Outs" values={stats.fielding.runOuts} labelClass={styles.fldLbl} />
-          <StatRow label="Stumpings" values={stats.fielding.stumpings} labelClass={styles.fldLbl} />
-        </div>
-
-      </div>
-    </div>
-  )
-}
-
-// Helper: Standard Stat Row (Label + 3 bubbles)
-const StatRow = ({ label, values, labelClass }: { label: string, values: StatValue, labelClass: string }) => (
-  <div className={styles.statRow}>
-    <div className={`${styles.statLabel} ${labelClass}`}>{label}</div>
-    <div className={`${styles.bubble} ${styles.tv}`}>{values.test}</div>
-    <div className={`${styles.bubble} ${styles.ov}`}>{values.odi}</div>
-    <div className={`${styles.bubble} ${styles.pv}`}>{values.t20i}</div>
-  </div>
-)
-
-// Helper: Split Pill (Single background, two values)
-const SplitPill = ({ val1, val2, mode }: { val1: string | number, val2: string | number, mode: keyof StatValue }) => {
-  const colorClass = mode === 'test' ? styles.tv : mode === 'odi' ? styles.ov : styles.pv;
-  return (
-    <div className={styles.splitPill}>
-      <div className={`${styles.splitHalf} ${colorClass}`}>{val1}</div>
-      <div className={`${styles.splitHalf} ${colorClass}`}>{val2}</div>
+      <StatsGrid stats={stats} theme="light" />
     </div>
   )
 }

--- a/apps/web/src/components/card/StatsGrid.tsx
+++ b/apps/web/src/components/card/StatsGrid.tsx
@@ -1,0 +1,232 @@
+import type { PlayerStats, StatValue } from './StatCard'
+
+export interface StatsGridProps {
+  stats: PlayerStats
+  theme: 'light' | 'dark'
+}
+
+const tokens = {
+  light: {
+    bg: 'bg-[#fdf8ef]',
+    fmtTestBg: 'bg-[#166534]', fmtTestName: 'bg-[#dcfce7] text-[#166534]', fmtTestCount: 'text-[#dcfce7]',
+    fmtOdiBg: 'bg-[#1d4ed8]',  fmtOdiName: 'bg-[#eff6ff] text-[#1d4ed8]',  fmtOdiCount: 'text-[#eff6ff]',
+    fmtT20Bg: 'bg-[#be185d]',  fmtT20Name: 'bg-[#fdf2f8] text-[#be185d]',  fmtT20Count: 'text-[#fdf2f8]',
+    secBat: 'bg-[#fed7aa]', secBwl: 'bg-[#ddd6fe]', secFld: 'bg-[#fde68a]',
+    labelBat: 'text-[#c2410c] border-l-4 border-[#ea580c] bg-[#fdf8efcc]',
+    labelBwl: 'text-[#6d28d9] border-l-4 border-[#7c3aed] bg-[#fdf8efcc]',
+    labelFld: 'text-[#92400e] border-l-4 border-[#d97706] bg-[#fdf8efcc]',
+    splitLabelBat: 'text-[#c2410c] bg-[#fdf8ef8c]',
+    splitLabelBwl: 'text-[#6d28d9] bg-[#fdf8ef8c]',
+    bubble: 'bg-[#fdf8ef]',
+    tvColor: 'text-[#78350f]', ovColor: 'text-[#1e40af]', pvColor: 'text-[#9d174d]',
+  },
+  dark: {
+    bg: 'bg-zinc-900',
+    fmtTestBg: 'bg-[#14532d]', fmtTestName: 'bg-[#166534] text-[#bbf7d0]', fmtTestCount: 'text-[#bbf7d0]',
+    fmtOdiBg: 'bg-[#1e3a8a]',  fmtOdiName: 'bg-[#1d4ed8] text-[#bfdbfe]',  fmtOdiCount: 'text-[#bfdbfe]',
+    fmtT20Bg: 'bg-[#831843]',  fmtT20Name: 'bg-[#be185d] text-[#fce7f3]',  fmtT20Count: 'text-[#fce7f3]',
+    secBat: 'bg-[#431407]', secBwl: 'bg-[#2e1065]', secFld: 'bg-[#422006]',
+    labelBat: 'text-[#fb923c] border-l-4 border-[#ea580c] bg-zinc-800',
+    labelBwl: 'text-[#a78bfa] border-l-4 border-[#7c3aed] bg-zinc-800',
+    labelFld: 'text-[#fbbf24] border-l-4 border-[#d97706] bg-zinc-800',
+    splitLabelBat: 'text-[#fb923c] bg-zinc-800',
+    splitLabelBwl: 'text-[#a78bfa] bg-zinc-800',
+    bubble: 'bg-zinc-800',
+    tvColor: 'text-[#86efac]', ovColor: 'text-[#93c5fd]', pvColor: 'text-[#f9a8d4]',
+  },
+}
+
+type Tokens = typeof tokens.light
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const StatRow = ({
+  label,
+  values,
+  labelClass,
+  t,
+}: {
+  label: string
+  values: StatValue
+  labelClass: string
+  t: Tokens
+}) => (
+  <div className="flex items-stretch gap-[3px]">
+    <div
+      className={`w-[168px] shrink-0 flex items-center pr-[8px] pl-[10px] font-roboto-mono text-[21px] font-semibold whitespace-nowrap overflow-hidden rounded-[12px] ${labelClass}`}
+    >
+      {label}
+    </div>
+    <div
+      className={`flex-1 flex items-center justify-center rounded-[10px] font-roboto-mono font-bold text-[22px] py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.tvColor}`}
+    >
+      {values.test}
+    </div>
+    <div
+      className={`flex-1 flex items-center justify-center rounded-[10px] font-roboto-mono font-bold text-[22px] py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.ovColor}`}
+    >
+      {values.odi}
+    </div>
+    <div
+      className={`flex-1 flex items-center justify-center rounded-[10px] font-roboto-mono font-bold text-[22px] py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.pvColor}`}
+    >
+      {values.t20i}
+    </div>
+  </div>
+)
+
+const SplitPill = ({
+  val1,
+  val2,
+  bubbleClass,
+  colorClass,
+}: {
+  val1: string | number
+  val2: string | number
+  bubbleClass: string
+  colorClass: string
+}) => (
+  <div className="flex-1 flex items-stretch rounded-[10px] overflow-hidden gap-[2px]">
+    <div
+      className={`flex-1 flex items-center justify-center font-roboto-mono font-bold text-[20px] py-1 px-[2px] whitespace-nowrap rounded-l-[10px] ${bubbleClass} ${colorClass}`}
+    >
+      {val1}
+    </div>
+    <div
+      className={`flex-1 flex items-center justify-center font-roboto-mono font-bold text-[20px] py-1 px-[2px] whitespace-nowrap rounded-r-[10px] ${bubbleClass} ${colorClass}`}
+    >
+      {val2}
+    </div>
+  </div>
+)
+
+interface SplitRowProps {
+  lbl1: string
+  lbl2: string
+  splitLabelClass: string
+  borderClass: string
+  val1Test: string | number
+  val2Test: string | number
+  val1Odi: string | number
+  val2Odi: string | number
+  val1T20: string | number
+  val2T20: string | number
+  t: Tokens
+}
+
+const SplitRow = ({
+  lbl1, lbl2,
+  splitLabelClass,
+  borderClass,
+  val1Test, val2Test,
+  val1Odi, val2Odi,
+  val1T20, val2T20,
+  t,
+}: SplitRowProps) => (
+  <div className="flex items-stretch gap-[3px]">
+    <div className="w-[168px] shrink-0 flex items-stretch rounded-[12px] overflow-hidden gap-[2px]">
+      <div
+        className={`flex-1 flex items-center pl-[10px] pr-1 font-roboto-mono text-[21px] font-semibold whitespace-nowrap rounded-l-[12px] border-l-4 ${borderClass} ${splitLabelClass}`}
+      >
+        {lbl1}
+      </div>
+      <div
+        className={`flex-1 flex items-center px-1 font-roboto-mono text-[21px] font-semibold whitespace-nowrap ${splitLabelClass}`}
+      >
+        {lbl2}
+      </div>
+    </div>
+    <SplitPill val1={val1Test} val2={val2Test} bubbleClass={t.bubble} colorClass={t.tvColor} />
+    <SplitPill val1={val1Odi} val2={val2Odi} bubbleClass={t.bubble} colorClass={t.ovColor} />
+    <SplitPill val1={val1T20} val2={val2T20} bubbleClass={t.bubble} colorClass={t.pvColor} />
+  </div>
+)
+
+// ─── StatsGrid ────────────────────────────────────────────────────────────────
+
+export const StatsGrid = ({ stats, theme }: StatsGridProps) => {
+  const t = tokens[theme]
+
+  return (
+    <div className={`flex-none flex flex-col gap-[2.5px] pb-[15px] pr-[15px] pl-[10px] ${t.bg}`}>
+      {/* FORMAT HEADER */}
+      <div className="flex gap-[3px] mb-[2px]">
+        <div className="w-[168px] shrink-0" />
+        <div className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtTestBg}`}>
+          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtTestName}`}>
+            Test
+          </div>
+          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtTestCount}`}>
+            {stats.matches.test}
+          </div>
+        </div>
+        <div className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtOdiBg}`}>
+          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtOdiName}`}>
+            ODI
+          </div>
+          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtOdiCount}`}>
+            {stats.matches.odi}
+          </div>
+        </div>
+        <div className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtT20Bg}`}>
+          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtT20Name}`}>
+            T20I
+          </div>
+          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtT20Count}`}>
+            {stats.matches.t20i}
+          </div>
+        </div>
+      </div>
+
+      {/* BATTING */}
+      <div className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secBat}`}>
+        <StatRow label="Runs" values={stats.batting.runs} labelClass={t.labelBat} t={t} />
+        <StatRow label="Not Outs" values={stats.batting.notOuts} labelClass={t.labelBat} t={t} />
+        <StatRow label="High Score" values={stats.batting.highScore} labelClass={t.labelBat} t={t} />
+        <StatRow label="Bat. Avg" values={stats.batting.avg} labelClass={t.labelBat} t={t} />
+        <SplitRow
+          lbl1="50s" lbl2="100s"
+          splitLabelClass={t.splitLabelBat}
+          borderClass="border-[#ea580c]"
+          val1Test={stats.batting.halfCenturies.test} val2Test={stats.batting.centuries.test}
+          val1Odi={stats.batting.halfCenturies.odi}   val2Odi={stats.batting.centuries.odi}
+          val1T20={stats.batting.halfCenturies.t20i}  val2T20={stats.batting.centuries.t20i}
+          t={t}
+        />
+        <SplitRow
+          lbl1="4s" lbl2="6s"
+          splitLabelClass={t.splitLabelBat}
+          borderClass="border-[#ea580c]"
+          val1Test={stats.batting.fours.test} val2Test={stats.batting.sixes.test}
+          val1Odi={stats.batting.fours.odi}   val2Odi={stats.batting.sixes.odi}
+          val1T20={stats.batting.fours.t20i}  val2T20={stats.batting.sixes.t20i}
+          t={t}
+        />
+      </div>
+
+      {/* BOWLING */}
+      <div className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secBwl}`}>
+        <StatRow label="Wickets" values={stats.bowling.wickets} labelClass={t.labelBwl} t={t} />
+        <StatRow label="Best Bowl" values={stats.bowling.bestBowl} labelClass={t.labelBwl} t={t} />
+        <StatRow label="Bowl Avg" values={stats.bowling.avg} labelClass={t.labelBwl} t={t} />
+        <StatRow label="Economy" values={stats.bowling.economy} labelClass={t.labelBwl} t={t} />
+        <SplitRow
+          lbl1="4W" lbl2="5W"
+          splitLabelClass={t.splitLabelBwl}
+          borderClass="border-[#7c3aed]"
+          val1Test={stats.bowling.fourWkts.test} val2Test={stats.bowling.fiveWkts.test}
+          val1Odi={stats.bowling.fourWkts.odi}   val2Odi={stats.bowling.fiveWkts.odi}
+          val1T20={stats.bowling.fourWkts.t20i}  val2T20={stats.bowling.fiveWkts.t20i}
+          t={t}
+        />
+      </div>
+
+      {/* FIELDING */}
+      <div className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secFld}`}>
+        <StatRow label="Catches" values={stats.fielding.catches} labelClass={t.labelFld} t={t} />
+        <StatRow label="Run Outs" values={stats.fielding.runOuts} labelClass={t.labelFld} t={t} />
+        <StatRow label="Stumpings" values={stats.fielding.stumpings} labelClass={t.labelFld} t={t} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/adapters/playerToStatCard.ts
+++ b/apps/web/src/lib/adapters/playerToStatCard.ts
@@ -1,0 +1,66 @@
+import type { PlayerWithAllStats } from '@/lib/queries/types'
+import type { PlayerStats, StatValue } from '@/components/card/StatCard'
+
+function sv(
+  a: number | string | null | undefined,
+  b: number | string | null | undefined,
+  c: number | string | null | undefined,
+): StatValue {
+  return { test: a ?? '-', odi: b ?? '-', t20i: c ?? '-' }
+}
+
+function cap(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function playerToStatCard(
+  data: PlayerWithAllStats,
+  cardNumber: string,
+  rarity: string,
+): PlayerStats {
+  const { player, stats } = data
+  const t = stats.test
+  const o = stats.odi
+  const p = stats.t20i
+
+  const KALLIS_ID = 'c6806b06-0903-498e-82d5-9b5cbd0e0f7c'
+  const image =
+    player.id === KALLIS_ID
+      ? '/images/players/kallis.jpg'
+      : (player.photo_url ?? '/images/card/player-placeholder.svg')
+
+  return {
+    info: {
+      number: cardNumber,
+      rarity,
+      name: player.name,
+      country: player.country,
+      role: cap(player.role),
+      image,
+    },
+    matches: sv(t?.bat_matches, o?.bat_matches, p?.bat_matches),
+    batting: {
+      runs: sv(t?.bat_runs, o?.bat_runs, p?.bat_runs),
+      notOuts: sv(t?.bat_not_outs, o?.bat_not_outs, p?.bat_not_outs),
+      highScore: sv(t?.bat_highest, o?.bat_highest, p?.bat_highest),
+      avg: sv(t?.bat_average, o?.bat_average, p?.bat_average),
+      halfCenturies: sv(t?.bat_50s, o?.bat_50s, p?.bat_50s),
+      centuries: sv(t?.bat_100s, o?.bat_100s, p?.bat_100s),
+      fours: sv(t?.bat_fours, o?.bat_fours, p?.bat_fours),
+      sixes: sv(t?.bat_sixes, o?.bat_sixes, p?.bat_sixes),
+    },
+    bowling: {
+      wickets: sv(t?.bowl_wickets, o?.bowl_wickets, p?.bowl_wickets),
+      bestBowl: sv(t?.bowl_best, o?.bowl_best, p?.bowl_best),
+      avg: sv(t?.bowl_average, o?.bowl_average, p?.bowl_average),
+      economy: sv(t?.bowl_economy, o?.bowl_economy, p?.bowl_economy),
+      fourWkts: sv(t?.bowl_4w, o?.bowl_4w, p?.bowl_4w),
+      fiveWkts: sv(t?.bowl_5w, o?.bowl_5w, p?.bowl_5w),
+    },
+    fielding: {
+      catches: sv(t?.field_catches, o?.field_catches, p?.field_catches),
+      runOuts: sv(t?.field_runouts, o?.field_runouts, p?.field_runouts),
+      stumpings: sv(t?.field_stumpings, o?.field_stumpings, p?.field_stumpings),
+    },
+  }
+}

--- a/apps/web/src/lib/queries/players.ts
+++ b/apps/web/src/lib/queries/players.ts
@@ -18,7 +18,7 @@ function toQueryError(error: unknown): { message: string; code?: string } {
 export async function fetchPlayersWithFormatStats(
   filters: PlayerWithFormatFilter = {}
 ): Promise<QueryResult<PlayerWithFormatStats[]>> {
-  const { country, role, isActive, format = 'odi' } = filters
+  const { country, role, isActive, format = 'odi', search } = filters
   const supabase = await createSupabaseServerClient()
 
   let playersQuery = supabase
@@ -29,6 +29,7 @@ export async function fetchPlayersWithFormatStats(
   if (country !== undefined) playersQuery = playersQuery.eq('country', country)
   if (role !== undefined) playersQuery = playersQuery.eq('role', role)
   if (isActive !== undefined) playersQuery = playersQuery.eq('is_active', isActive)
+  if (search !== undefined) playersQuery = playersQuery.ilike('name', `%${search}%`)
 
   const { data: players, error: playersError } = await playersQuery
 

--- a/apps/web/src/lib/queries/types.ts
+++ b/apps/web/src/lib/queries/types.ts
@@ -8,6 +8,7 @@ export interface PlayerFilters {
 
 export interface PlayerWithFormatFilter extends PlayerFilters {
   format?: CricketFormat
+  search?: string
 }
 
 export interface PlayerWithFormatStats {


### PR DESCRIPTION
## Summary

- **Players listing page** — search by name, filter by country (dropdown) and role (pills), player cards with headline stat
- **Player detail page** — Card View shows StatCard + BrandCard (Alpha Shot, no tinting); Table View shows StatsGrid in dark theme
- **StatsGrid** — new Tailwind-only component replacing inline stats in StatCard; supports `light` and `dark` themes via a token map
- **StatCard** refactored to delegate stats area to StatsGrid (light theme), removing ~100 lines of inline rendering
- **LayeredCharacter / BrandCard** — colors prop made partial; color overlay skipped when value is undefined, allowing original PNG colours to show through
- **playerToStatCard adapter** — maps `PlayerWithAllStats` → `PlayerStats`, with Kallis photo override
- Detail page layout: top bar with back link left-anchored and player name/country/role centred

## Test plan

- [ ] `/players` — listing loads, search filters by name, country dropdown filters, role pills filter
- [ ] `/players/[id]` — Card View shows StatCard and BrandCard side by side at 0.5 scale
- [ ] BrandCard renders Alpha Shot pose with original PNG colours (no blue tint)
- [ ] `/players/[id]?view=table` — Table View shows StatsGrid dark theme with player name header
- [ ] Light theme StatCard unchanged visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)