### PR TITLE
feat: update fonts, StatsGrid variants, and home nav

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Inter, Roboto_Mono, Supermercado_One } from 'next/font/google'
+import { Inter, Roboto_Mono, Fredoka, Sour_Gummy, Inconsolata } from 'next/font/google'
 import './globals.css'
 
 const inter = Inter({
@@ -12,10 +12,22 @@ const robotoMono = Roboto_Mono({
   variable: '--font-roboto-mono',
 })
 
-const supermercado = Supermercado_One({
+const inconsolata = Inconsolata({
   subsets: ['latin'],
-  weight: '400',
-  variable: '--font-supermercado',
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-inconsolata',
+})
+
+const sourGummy = Sour_Gummy({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700', '900'],
+  variable: '--font-sour-gummy',
+})
+
+const fredoka = Fredoka({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-fredoka',
 })
 
 export const metadata: Metadata = {
@@ -36,7 +48,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={`${inter.variable} ${robotoMono.variable} ${supermercado.variable} dark`}>
+    <html lang="en" className={`${inter.variable} ${robotoMono.variable} ${fredoka.variable} ${sourGummy.variable} ${inconsolata.variable} dark`}>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,36 +1,40 @@
-import Link from 'next/link'
-import { MobileContainer } from '@/components/layout/MobileContainer'
+import Link from "next/link";
+import { MobileContainer } from "@/components/layout/MobileContainer";
 
 const features = [
   {
-    icon: '🃏',
-    title: 'Collect',
-    description: 'Build your collection of legendary 90s cricketers. From common to legendary rarity.',
-    href: '/collection',
-    color: 'border-blue-400/30 bg-blue-400/5',
+    icon: "🃏",
+    title: "Collect",
+    description:
+      "Build your collection of legendary 90s cricketers. From common to legendary rarity.",
+    href: "/collection",
+    color: "border-blue-400/30 bg-blue-400/5",
   },
   {
-    icon: '📦',
-    title: 'Packs',
-    description: 'Open packs to discover new players. Every pack is a mystery waiting to be revealed.',
-    href: '/packs',
-    color: 'border-gold/30 bg-gold/5',
+    icon: "📦",
+    title: "Packs",
+    description:
+      "Open packs to discover new players. Every pack is a mystery waiting to be revealed.",
+    href: "/packs",
+    color: "border-gold/30 bg-gold/5",
   },
   {
-    icon: '🔄',
-    title: 'Trade',
-    description: 'Trade cards with other collectors. Complete your collection through smart swaps.',
-    href: '/trade',
-    color: 'border-green-400/30 bg-green-400/5',
+    icon: "🔄",
+    title: "Trade",
+    description:
+      "Trade cards with other collectors. Complete your collection through smart swaps.",
+    href: "/trade",
+    color: "border-green-400/30 bg-green-400/5",
   },
   {
-    icon: '⚔️',
-    title: 'Battle',
-    description: 'Pit your best players against rivals. Stats decide who reigns supreme.',
-    href: '/battle',
-    color: 'border-brand/30 bg-brand/5',
+    icon: "⚔️",
+    title: "Battle",
+    description:
+      "Pit your best players against rivals. Stats decide who reigns supreme.",
+    href: "/battle",
+    color: "border-brand/30 bg-brand/5",
   },
-]
+];
 
 export default function HomePage() {
   return (
@@ -40,10 +44,10 @@ export default function HomePage() {
         <section className="relative flex flex-col items-center justify-center px-6 pt-16 pb-10 text-center overflow-hidden">
           {/* Background decorative elements */}
           <div
-            className="absolute inset-0 opacity-5"
+            className="absolute inset-0 opacity-5 pointer-events-none"
             style={{
               backgroundImage:
-                'radial-gradient(circle at 50% 0%, #e63946 0%, transparent 60%)',
+                "radial-gradient(circle at 50% 0%, #e63946 0%, transparent 60%)",
             }}
           />
           <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-brand via-gold to-pitch" />
@@ -71,13 +75,14 @@ export default function HomePage() {
             Relive the 90s. Collect legends.
           </p>
           <p className="text-gray-500 text-sm mb-8 max-w-xs">
-            Inspired by Big Babol Pocket Cricket — the cards you traded on the playground.
+            Inspired by Big Babol Pocket Cricket — the cards you traded on the
+            playground.
           </p>
 
           {/* CTA Buttons */}
           <div className="flex flex-col gap-3 w-full max-w-xs">
             <Link
-              href="/collection"
+              href="/players"
               className="w-full bg-brand hover:bg-red-600 text-white font-bold py-3.5 px-6 rounded-xl text-base transition-all duration-200 active:scale-95 shadow-lg shadow-brand/20 text-center"
             >
               Start Collecting
@@ -99,7 +104,9 @@ export default function HomePage() {
         {/* Divider */}
         <div className="flex items-center gap-3 px-6 py-2">
           <div className="flex-1 h-px bg-gray-800" />
-          <span className="text-gray-600 text-xs font-medium uppercase tracking-widest">Four Pillars</span>
+          <span className="text-gray-600 text-xs font-medium uppercase tracking-widest">
+            Four Pillars
+          </span>
           <div className="flex-1 h-px bg-gray-800" />
         </div>
 
@@ -136,5 +143,5 @@ export default function HomePage() {
         </footer>
       </main>
     </MobileContainer>
-  )
+  );
 }

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -46,7 +46,7 @@ export default async function PlayerDetailPage({
   return (
     <main className="bg-zinc-950 min-h-screen">
       {/* Top bar */}
-      <div className="px-8 pt-8 flex items-center gap-6">
+      <div className="px-8 pt-4 flex items-center gap-6">
         <Link
           href="/players"
           className="text-zinc-500 hover:text-zinc-300 text-sm font-mono tracking-wider transition-colors flex-shrink-0"
@@ -67,9 +67,9 @@ export default async function PlayerDetailPage({
         <div className="flex-shrink-0 w-20" />
       </div>
 
-      <div className="px-8 py-8">
+      <div className="px-8 py-4">
         {/* View tabs */}
-        <div className="flex gap-2 mb-8 justify-center mt-6">
+        <div className="flex gap-2 mb-4 justify-center mt-2">
           {(["card", "table"] as const).map((v) => (
             <Link
               key={v}
@@ -112,7 +112,7 @@ export default async function PlayerDetailPage({
         ) : (
           <div className="max-w-3xl mx-auto">
             <div className="rounded-2xl overflow-hidden border border-zinc-800">
-              <StatsGrid stats={playerStats} theme="dark" />
+              <StatsGrid stats={playerStats} theme="dark" variant="page" />
             </div>
           </div>
         )}

--- a/apps/web/src/components/card/BrandCard.tsx
+++ b/apps/web/src/components/card/BrandCard.tsx
@@ -71,7 +71,7 @@ export const BrandCard: React.FC<BrandCardProps> = ({
           transition={{ delay: 0.5, duration: 1 }}
           className="text-center"
         >
-          <p className="font-supermercado text-5xl text-slate-800 font-bold">
+          <p className="font-fredoka text-5xl text-slate-800 font-bold">
             Limited Edition
           </p>
           <div className="w-24 h-1 bg-slate-200 mx-auto mt-4 rounded-full" />

--- a/apps/web/src/components/card/StatCard.module.css
+++ b/apps/web/src/components/card/StatCard.module.css
@@ -106,31 +106,47 @@
     rgba(0, 122, 77, 0.28) 0%,
     rgba(255, 184, 28, 0.22) 30%,
     rgba(253, 248, 239, 0.05) 50%,
-    rgba(222, 56, 49, 0.20) 72%,
+    rgba(222, 56, 49, 0.2) 72%,
     rgba(0, 0, 0, 0.15) 100%
   );
 }
 
 .middleZone::before {
-  content: '';
+  content: "";
   position: absolute;
   left: 18px;
   top: 18%;
   bottom: 18%;
   width: 8px;
-  background: linear-gradient(to bottom, #007A4D 0%, #007A4D 33%, #FFB81C 33%, #FFB81C 66%, #DE3831 66%, #DE3831 100%);
+  background: linear-gradient(
+    to bottom,
+    #007a4d 0%,
+    #007a4d 33%,
+    #ffb81c 33%,
+    #ffb81c 66%,
+    #de3831 66%,
+    #de3831 100%
+  );
   border-radius: 4px;
   opacity: 0.55;
 }
 
 .middleZone::after {
-  content: '';
+  content: "";
   position: absolute;
   right: 18px;
   top: 18%;
   bottom: 18%;
   width: 8px;
-  background: linear-gradient(to bottom, #007A4D 0%, #007A4D 33%, #FFB81C 33%, #FFB81C 66%, #DE3831 66%, #DE3831 100%);
+  background: linear-gradient(
+    to bottom,
+    #007a4d 0%,
+    #007a4d 33%,
+    #ffb81c 33%,
+    #ffb81c 66%,
+    #de3831 66%,
+    #de3831 100%
+  );
   border-radius: 4px;
   opacity: 0.55;
 }
@@ -164,9 +180,18 @@
   overflow: hidden;
 }
 
-.fmtBubbleTest { background: #166534; border: 1px solid #166534; }
-.fmtBubbleOdi  { background: #1d4ed8; border: 1px solid #1d4ed8; }
-.fmtBubbleT20  { background: #be185d; border: 1px solid #be185d; }
+.fmtBubbleTest {
+  background: #166534;
+  border: 1px solid #166534;
+}
+.fmtBubbleOdi {
+  background: #1d4ed8;
+  border: 1px solid #1d4ed8;
+}
+.fmtBubbleT20 {
+  background: #be185d;
+  border: 1px solid #be185d;
+}
 
 .fmtNameSide {
   flex: 1;
@@ -190,13 +215,28 @@
   padding: 5px 0;
 }
 
-.fmtBubbleTest .fmtCountSide { color: #dcfce7; }
-.fmtBubbleOdi  .fmtCountSide { color: #eff6ff; }
-.fmtBubbleT20  .fmtCountSide { color: #fdf2f8; }
+.fmtBubbleTest .fmtCountSide {
+  color: #dcfce7;
+}
+.fmtBubbleOdi .fmtCountSide {
+  color: #eff6ff;
+}
+.fmtBubbleT20 .fmtCountSide {
+  color: #fdf2f8;
+}
 
-.fmtBubbleTest .fmtNameSide { background: #dcfce7; color: #166534; }
-.fmtBubbleOdi  .fmtNameSide { background: #eff6ff; color: #1d4ed8; }
-.fmtBubbleT20  .fmtNameSide { background: #fdf2f8; color: #be185d; }
+.fmtBubbleTest .fmtNameSide {
+  background: #dcfce7;
+  color: #166534;
+}
+.fmtBubbleOdi .fmtNameSide {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+.fmtBubbleT20 .fmtNameSide {
+  background: #fdf2f8;
+  color: #be185d;
+}
 
 /* SECTIONS */
 .section {
@@ -207,9 +247,15 @@
   gap: 1.5px;
 }
 
-.secBat { background: #fed7aa; }
-.secBwl { background: #ddd6fe; }
-.secFld { background: #fde68a; }
+.secBat {
+  background: #fed7aa;
+}
+.secBwl {
+  background: #ddd6fe;
+}
+.secFld {
+  background: #fde68a;
+}
 
 /* STAT ROW */
 .statRow {
@@ -233,9 +279,18 @@
   background: rgba(253, 248, 239, 0.55);
 }
 
-.batLbl { color: #c2410c; border-left: 4px solid #ea580c; }
-.bwlLbl { color: #6d28d9; border-left: 4px solid #7c3aed; }
-.fldLbl { color: #92400e; border-left: 4px solid #d97706; }
+.batLbl {
+  color: #c2410c;
+  border-left: 4px solid #ea580c;
+}
+.bwlLbl {
+  color: #6d28d9;
+  border-left: 4px solid #7c3aed;
+}
+.fldLbl {
+  color: #92400e;
+  border-left: 4px solid #d97706;
+}
 
 /* VALUE BUBBLE */
 .bubble {
@@ -252,7 +307,15 @@
   white-space: nowrap;
 }
 
-.tv { color: #78350f; } .ov { color: #1e40af; } .pv { color: #9d174d; }
+.tv {
+  color: #78350f;
+}
+.ov {
+  color: #1e40af;
+}
+.pv {
+  color: #9d174d;
+}
 
 /* SPLIT ROW */
 .splitRow {
@@ -268,7 +331,6 @@
   border-radius: 12px;
   overflow: hidden;
   gap: 2px;
-
 }
 
 .splitLblL {
@@ -352,5 +414,9 @@
   white-space: nowrap;
 }
 
-.splitHalf:first-child { border-radius: 10px 0 0 10px; }
-.splitHalf:last-child  { border-radius: 0 10px 10px 0; }
+.splitHalf:first-child {
+  border-radius: 10px 0 0 10px;
+}
+.splitHalf:last-child {
+  border-radius: 0 10px 10px 0;
+}

--- a/apps/web/src/components/card/StatCard.tsx
+++ b/apps/web/src/components/card/StatCard.tsx
@@ -71,7 +71,7 @@ export default function StatCard({ stats }: { stats: PlayerStats }) {
       {/* MIDDLE ZONE */}
       <div className={styles.middleZone}></div>
 
-      <StatsGrid stats={stats} theme="light" />
+      <StatsGrid stats={stats} theme="light" variant="card" />
     </div>
   )
 }

--- a/apps/web/src/components/card/StatsGrid.tsx
+++ b/apps/web/src/components/card/StatsGrid.tsx
@@ -1,42 +1,81 @@
-import type { PlayerStats, StatValue } from './StatCard'
+import type { PlayerStats, StatValue } from "./StatCard";
 
 export interface StatsGridProps {
-  stats: PlayerStats
-  theme: 'light' | 'dark'
+  stats: PlayerStats;
+  theme: "light" | "dark";
+  variant?: "card" | "page";
 }
 
 const tokens = {
   light: {
-    bg: 'bg-[#fdf8ef]',
-    fmtTestBg: 'bg-[#166534]', fmtTestName: 'bg-[#dcfce7] text-[#166534]', fmtTestCount: 'text-[#dcfce7]',
-    fmtOdiBg: 'bg-[#1d4ed8]',  fmtOdiName: 'bg-[#eff6ff] text-[#1d4ed8]',  fmtOdiCount: 'text-[#eff6ff]',
-    fmtT20Bg: 'bg-[#be185d]',  fmtT20Name: 'bg-[#fdf2f8] text-[#be185d]',  fmtT20Count: 'text-[#fdf2f8]',
-    secBat: 'bg-[#fed7aa]', secBwl: 'bg-[#ddd6fe]', secFld: 'bg-[#fde68a]',
-    labelBat: 'text-[#c2410c] border-l-4 border-[#ea580c] bg-[#fdf8efcc]',
-    labelBwl: 'text-[#6d28d9] border-l-4 border-[#7c3aed] bg-[#fdf8efcc]',
-    labelFld: 'text-[#92400e] border-l-4 border-[#d97706] bg-[#fdf8efcc]',
-    splitLabelBat: 'text-[#c2410c] bg-[#fdf8ef8c]',
-    splitLabelBwl: 'text-[#6d28d9] bg-[#fdf8ef8c]',
-    bubble: 'bg-[#fdf8ef]',
-    tvColor: 'text-[#78350f]', ovColor: 'text-[#1e40af]', pvColor: 'text-[#9d174d]',
+    bg: "bg-[#fdf8ef]",
+    fmtTestBg: "bg-[#166534]",
+    fmtTestName: "bg-[#dcfce7] text-[#166534]",
+    fmtTestCount: "text-[#dcfce7]",
+    fmtOdiBg: "bg-[#1d4ed8]",
+    fmtOdiName: "bg-[#eff6ff] text-[#1d4ed8]",
+    fmtOdiCount: "text-[#eff6ff]",
+    fmtT20Bg: "bg-[#be185d]",
+    fmtT20Name: "bg-[#fdf2f8] text-[#be185d]",
+    fmtT20Count: "text-[#fdf2f8]",
+    secBat: "bg-[#fed7aa]",
+    secBwl: "bg-[#ddd6fe]",
+    secFld: "bg-[#fde68a]",
+    labelBat: "text-[#c2410c] border-l-4 border-[#ea580c] bg-[#fdf8efcc]",
+    labelBwl: "text-[#6d28d9] border-l-4 border-[#7c3aed] bg-[#fdf8efcc]",
+    labelFld: "text-[#92400e] border-l-4 border-[#d97706] bg-[#fdf8efcc]",
+    splitLabelBat: "text-[#c2410c] bg-[#fdf8ef8c]",
+    splitLabelBwl: "text-[#6d28d9] bg-[#fdf8ef8c]",
+    bubble: "bg-[#fdf8ef]",
+    tvColor: "text-[#78350f]",
+    ovColor: "text-[#1e40af]",
+    pvColor: "text-[#9d174d]",
   },
   dark: {
-    bg: 'bg-zinc-900',
-    fmtTestBg: 'bg-[#14532d]', fmtTestName: 'bg-[#166534] text-[#bbf7d0]', fmtTestCount: 'text-[#bbf7d0]',
-    fmtOdiBg: 'bg-[#1e3a8a]',  fmtOdiName: 'bg-[#1d4ed8] text-[#bfdbfe]',  fmtOdiCount: 'text-[#bfdbfe]',
-    fmtT20Bg: 'bg-[#831843]',  fmtT20Name: 'bg-[#be185d] text-[#fce7f3]',  fmtT20Count: 'text-[#fce7f3]',
-    secBat: 'bg-[#431407]', secBwl: 'bg-[#2e1065]', secFld: 'bg-[#422006]',
-    labelBat: 'text-[#fb923c] border-l-4 border-[#ea580c] bg-zinc-800',
-    labelBwl: 'text-[#a78bfa] border-l-4 border-[#7c3aed] bg-zinc-800',
-    labelFld: 'text-[#fbbf24] border-l-4 border-[#d97706] bg-zinc-800',
-    splitLabelBat: 'text-[#fb923c] bg-zinc-800',
-    splitLabelBwl: 'text-[#a78bfa] bg-zinc-800',
-    bubble: 'bg-zinc-800',
-    tvColor: 'text-[#86efac]', ovColor: 'text-[#93c5fd]', pvColor: 'text-[#f9a8d4]',
+    bg: "bg-zinc-900",
+    fmtTestBg: "bg-[#14532d]",
+    fmtTestName: "bg-[#166534] text-[#bbf7d0]",
+    fmtTestCount: "text-[#bbf7d0]",
+    fmtOdiBg: "bg-[#1e3a8a]",
+    fmtOdiName: "bg-[#1d4ed8] text-[#bfdbfe]",
+    fmtOdiCount: "text-[#bfdbfe]",
+    fmtT20Bg: "bg-[#831843]",
+    fmtT20Name: "bg-[#be185d] text-[#fce7f3]",
+    fmtT20Count: "text-[#fce7f3]",
+    secBat: "bg-[#431407]",
+    secBwl: "bg-[#2e1065]",
+    secFld: "bg-[#422006]",
+    labelBat: "text-[#fb923c] border-l-4 border-[#ea580c] bg-zinc-800",
+    labelBwl: "text-[#a78bfa] border-l-4 border-[#7c3aed] bg-zinc-800",
+    labelFld: "text-[#fbbf24] border-l-4 border-[#d97706] bg-zinc-800",
+    splitLabelBat: "text-[#fb923c] bg-zinc-800",
+    splitLabelBwl: "text-[#a78bfa] bg-zinc-800",
+    bubble: "bg-zinc-800",
+    tvColor: "text-[#86efac]",
+    ovColor: "text-[#93c5fd]",
+    pvColor: "text-[#f9a8d4]",
   },
-}
+};
 
-type Tokens = typeof tokens.light
+const variantTokens = {
+  card: {
+    font: "font-roboto-mono",
+    szLabel: "text-[21px]",
+    szValue: "text-[22px]",
+    szSplit: "text-[20px]",
+    szHeader: "text-[22px]",
+  },
+  page: {
+    font: "font-inconsolata",
+    szLabel: "text-[17px]",
+    szValue: "text-[17px]",
+    szSplit: "text-[16px]",
+    szHeader: "text-[17px]",
+  },
+};
+
+type Tokens = typeof tokens.light;
+type VTokens = typeof variantTokens.card;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -45,188 +84,243 @@ const StatRow = ({
   values,
   labelClass,
   t,
+  v,
 }: {
-  label: string
-  values: StatValue
-  labelClass: string
-  t: Tokens
+  label: string;
+  values: StatValue;
+  labelClass: string;
+  t: Tokens;
+  v: VTokens;
 }) => (
   <div className="flex items-stretch gap-[3px]">
     <div
-      className={`w-[168px] shrink-0 flex items-center pr-[8px] pl-[10px] font-roboto-mono text-[21px] font-semibold whitespace-nowrap overflow-hidden rounded-[12px] ${labelClass}`}
+      className={`w-[168px] shrink-0 flex items-center pr-[8px] pl-[10px] ${v.font} ${v.szLabel} font-semibold whitespace-nowrap overflow-hidden rounded-[12px] ${labelClass}`}
     >
       {label}
     </div>
     <div
-      className={`flex-1 flex items-center justify-center rounded-[10px] font-roboto-mono font-bold text-[22px] py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.tvColor}`}
+      className={`flex-1 flex items-center justify-center rounded-[10px] ${v.font} font-bold ${v.szValue} py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.tvColor}`}
     >
       {values.test}
     </div>
     <div
-      className={`flex-1 flex items-center justify-center rounded-[10px] font-roboto-mono font-bold text-[22px] py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.ovColor}`}
+      className={`flex-1 flex items-center justify-center rounded-[10px] ${v.font} font-bold ${v.szValue} py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.ovColor}`}
     >
       {values.odi}
     </div>
     <div
-      className={`flex-1 flex items-center justify-center rounded-[10px] font-roboto-mono font-bold text-[22px] py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.pvColor}`}
+      className={`flex-1 flex items-center justify-center rounded-[10px] ${v.font} font-bold ${v.szValue} py-1 px-[2px] whitespace-nowrap ${t.bubble} ${t.pvColor}`}
     >
       {values.t20i}
     </div>
   </div>
-)
+);
 
 const SplitPill = ({
   val1,
   val2,
   bubbleClass,
   colorClass,
+  v,
 }: {
-  val1: string | number
-  val2: string | number
-  bubbleClass: string
-  colorClass: string
+  val1: string | number;
+  val2: string | number;
+  bubbleClass: string;
+  colorClass: string;
+  v: VTokens;
 }) => (
   <div className="flex-1 flex items-stretch rounded-[10px] overflow-hidden gap-[2px]">
     <div
-      className={`flex-1 flex items-center justify-center font-roboto-mono font-bold text-[20px] py-1 px-[2px] whitespace-nowrap rounded-l-[10px] ${bubbleClass} ${colorClass}`}
+      className={`flex-1 flex items-center justify-center ${v.font} font-bold ${v.szSplit} py-1 px-[2px] whitespace-nowrap rounded-l-[10px] ${bubbleClass} ${colorClass}`}
     >
       {val1}
     </div>
     <div
-      className={`flex-1 flex items-center justify-center font-roboto-mono font-bold text-[20px] py-1 px-[2px] whitespace-nowrap rounded-r-[10px] ${bubbleClass} ${colorClass}`}
+      className={`flex-1 flex items-center justify-center ${v.font} font-bold ${v.szSplit} py-1 px-[2px] whitespace-nowrap rounded-r-[10px] ${bubbleClass} ${colorClass}`}
     >
       {val2}
     </div>
   </div>
-)
+);
 
 interface SplitRowProps {
-  lbl1: string
-  lbl2: string
-  splitLabelClass: string
-  borderClass: string
-  val1Test: string | number
-  val2Test: string | number
-  val1Odi: string | number
-  val2Odi: string | number
-  val1T20: string | number
-  val2T20: string | number
-  t: Tokens
+  lbl1: string;
+  lbl2: string;
+  splitLabelClass: string;
+  borderClass: string;
+  val1Test: string | number;
+  val2Test: string | number;
+  val1Odi: string | number;
+  val2Odi: string | number;
+  val1T20: string | number;
+  val2T20: string | number;
+  t: Tokens;
+  v: VTokens;
 }
 
 const SplitRow = ({
-  lbl1, lbl2,
+  lbl1,
+  lbl2,
   splitLabelClass,
   borderClass,
-  val1Test, val2Test,
-  val1Odi, val2Odi,
-  val1T20, val2T20,
+  val1Test,
+  val2Test,
+  val1Odi,
+  val2Odi,
+  val1T20,
+  val2T20,
   t,
+  v,
 }: SplitRowProps) => (
   <div className="flex items-stretch gap-[3px]">
     <div className="w-[168px] shrink-0 flex items-stretch rounded-[12px] overflow-hidden gap-[2px]">
       <div
-        className={`flex-1 flex items-center pl-[10px] pr-1 font-roboto-mono text-[21px] font-semibold whitespace-nowrap rounded-l-[12px] border-l-4 ${borderClass} ${splitLabelClass}`}
+        className={`flex-1 flex items-center pl-[10px] pr-1 ${v.font} ${v.szLabel} font-semibold whitespace-nowrap rounded-l-[12px] border-l-4 ${borderClass} ${splitLabelClass}`}
       >
         {lbl1}
       </div>
       <div
-        className={`flex-1 flex items-center px-1 font-roboto-mono text-[21px] font-semibold whitespace-nowrap ${splitLabelClass}`}
+        className={`flex-1 flex items-center px-1 ${v.font} ${v.szLabel} font-semibold whitespace-nowrap ${splitLabelClass}`}
       >
         {lbl2}
       </div>
     </div>
-    <SplitPill val1={val1Test} val2={val2Test} bubbleClass={t.bubble} colorClass={t.tvColor} />
-    <SplitPill val1={val1Odi} val2={val2Odi} bubbleClass={t.bubble} colorClass={t.ovColor} />
-    <SplitPill val1={val1T20} val2={val2T20} bubbleClass={t.bubble} colorClass={t.pvColor} />
+    <SplitPill
+      val1={val1Test}
+      val2={val2Test}
+      bubbleClass={t.bubble}
+      colorClass={t.tvColor}
+      v={v}
+    />
+    <SplitPill
+      val1={val1Odi}
+      val2={val2Odi}
+      bubbleClass={t.bubble}
+      colorClass={t.ovColor}
+      v={v}
+    />
+    <SplitPill
+      val1={val1T20}
+      val2={val2T20}
+      bubbleClass={t.bubble}
+      colorClass={t.pvColor}
+      v={v}
+    />
   </div>
-)
+);
 
 // ─── StatsGrid ────────────────────────────────────────────────────────────────
 
-export const StatsGrid = ({ stats, theme }: StatsGridProps) => {
-  const t = tokens[theme]
+export const StatsGrid = ({ stats, theme, variant = "page" }: StatsGridProps) => {
+  const t = tokens[theme];
+  const v = variantTokens[variant];
 
   return (
-    <div className={`flex-none flex flex-col gap-[2.5px] pb-[15px] pr-[15px] pl-[10px] ${t.bg}`}>
+    <div
+      className={`flex-none flex flex-col gap-[2.5px] pb-[15px] pr-[15px] pl-[10px] ${t.bg}`}
+    >
       {/* FORMAT HEADER */}
       <div className="flex gap-[3px] mb-[2px]">
         <div className="w-[168px] shrink-0" />
-        <div className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtTestBg}`}>
-          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtTestName}`}>
+        <div
+          className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtTestBg}`}
+        >
+          <div
+            className={`flex-1 flex items-center justify-center ${v.font} ${v.szHeader} font-bold py-[5px] ${t.fmtTestName}`}
+          >
             Test
           </div>
-          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtTestCount}`}>
+          <div
+            className={`flex-1 flex items-center justify-center ${v.font} ${v.szHeader} font-bold py-[5px] ${t.fmtTestCount}`}
+          >
             {stats.matches.test}
           </div>
         </div>
-        <div className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtOdiBg}`}>
-          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtOdiName}`}>
+        <div
+          className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtOdiBg}`}
+        >
+          <div
+            className={`flex-1 flex items-center justify-center ${v.font} ${v.szHeader} font-bold py-[5px] ${t.fmtOdiName}`}
+          >
             ODI
           </div>
-          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtOdiCount}`}>
+          <div
+            className={`flex-1 flex items-center justify-center ${v.font} ${v.szHeader} font-bold py-[5px] ${t.fmtOdiCount}`}
+          >
             {stats.matches.odi}
           </div>
         </div>
-        <div className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtT20Bg}`}>
-          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtT20Name}`}>
+        <div
+          className={`flex-1 flex items-stretch gap-[2px] rounded-[10px] overflow-hidden ${t.fmtT20Bg}`}
+        >
+          <div
+            className={`flex-1 flex items-center justify-center ${v.font} ${v.szHeader} font-bold py-[5px] ${t.fmtT20Name}`}
+          >
             T20I
           </div>
-          <div className={`flex-1 flex items-center justify-center font-roboto-mono text-[22px] font-bold py-[5px] ${t.fmtT20Count}`}>
+          <div
+            className={`flex-1 flex items-center justify-center ${v.font} ${v.szHeader} font-bold py-[5px] ${t.fmtT20Count}`}
+          >
             {stats.matches.t20i}
           </div>
         </div>
       </div>
 
       {/* BATTING */}
-      <div className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secBat}`}>
-        <StatRow label="Runs" values={stats.batting.runs} labelClass={t.labelBat} t={t} />
-        <StatRow label="Not Outs" values={stats.batting.notOuts} labelClass={t.labelBat} t={t} />
-        <StatRow label="High Score" values={stats.batting.highScore} labelClass={t.labelBat} t={t} />
-        <StatRow label="Bat. Avg" values={stats.batting.avg} labelClass={t.labelBat} t={t} />
+      <div
+        className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secBat}`}
+      >
+        <StatRow label="Runs" values={stats.batting.runs} labelClass={t.labelBat} t={t} v={v} />
+        <StatRow label="Not Outs" values={stats.batting.notOuts} labelClass={t.labelBat} t={t} v={v} />
+        <StatRow label="High Score" values={stats.batting.highScore} labelClass={t.labelBat} t={t} v={v} />
+        <StatRow label="Bat. Avg" values={stats.batting.avg} labelClass={t.labelBat} t={t} v={v} />
         <SplitRow
           lbl1="50s" lbl2="100s"
           splitLabelClass={t.splitLabelBat}
           borderClass="border-[#ea580c]"
           val1Test={stats.batting.halfCenturies.test} val2Test={stats.batting.centuries.test}
-          val1Odi={stats.batting.halfCenturies.odi}   val2Odi={stats.batting.centuries.odi}
-          val1T20={stats.batting.halfCenturies.t20i}  val2T20={stats.batting.centuries.t20i}
-          t={t}
+          val1Odi={stats.batting.halfCenturies.odi} val2Odi={stats.batting.centuries.odi}
+          val1T20={stats.batting.halfCenturies.t20i} val2T20={stats.batting.centuries.t20i}
+          t={t} v={v}
         />
         <SplitRow
           lbl1="4s" lbl2="6s"
           splitLabelClass={t.splitLabelBat}
           borderClass="border-[#ea580c]"
           val1Test={stats.batting.fours.test} val2Test={stats.batting.sixes.test}
-          val1Odi={stats.batting.fours.odi}   val2Odi={stats.batting.sixes.odi}
-          val1T20={stats.batting.fours.t20i}  val2T20={stats.batting.sixes.t20i}
-          t={t}
+          val1Odi={stats.batting.fours.odi} val2Odi={stats.batting.sixes.odi}
+          val1T20={stats.batting.fours.t20i} val2T20={stats.batting.sixes.t20i}
+          t={t} v={v}
         />
       </div>
 
       {/* BOWLING */}
-      <div className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secBwl}`}>
-        <StatRow label="Wickets" values={stats.bowling.wickets} labelClass={t.labelBwl} t={t} />
-        <StatRow label="Best Bowl" values={stats.bowling.bestBowl} labelClass={t.labelBwl} t={t} />
-        <StatRow label="Bowl Avg" values={stats.bowling.avg} labelClass={t.labelBwl} t={t} />
-        <StatRow label="Economy" values={stats.bowling.economy} labelClass={t.labelBwl} t={t} />
+      <div
+        className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secBwl}`}
+      >
+        <StatRow label="Wickets" values={stats.bowling.wickets} labelClass={t.labelBwl} t={t} v={v} />
+        <StatRow label="Best Bowl" values={stats.bowling.bestBowl} labelClass={t.labelBwl} t={t} v={v} />
+        <StatRow label="Bowl Avg" values={stats.bowling.avg} labelClass={t.labelBwl} t={t} v={v} />
+        <StatRow label="Economy" values={stats.bowling.economy} labelClass={t.labelBwl} t={t} v={v} />
         <SplitRow
           lbl1="4W" lbl2="5W"
           splitLabelClass={t.splitLabelBwl}
           borderClass="border-[#7c3aed]"
           val1Test={stats.bowling.fourWkts.test} val2Test={stats.bowling.fiveWkts.test}
-          val1Odi={stats.bowling.fourWkts.odi}   val2Odi={stats.bowling.fiveWkts.odi}
-          val1T20={stats.bowling.fourWkts.t20i}  val2T20={stats.bowling.fiveWkts.t20i}
-          t={t}
+          val1Odi={stats.bowling.fourWkts.odi} val2Odi={stats.bowling.fiveWkts.odi}
+          val1T20={stats.bowling.fourWkts.t20i} val2T20={stats.bowling.fiveWkts.t20i}
+          t={t} v={v}
         />
       </div>
 
       {/* FIELDING */}
-      <div className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secFld}`}>
-        <StatRow label="Catches" values={stats.fielding.catches} labelClass={t.labelFld} t={t} />
-        <StatRow label="Run Outs" values={stats.fielding.runOuts} labelClass={t.labelFld} t={t} />
-        <StatRow label="Stumpings" values={stats.fielding.stumpings} labelClass={t.labelFld} t={t} />
+      <div
+        className={`rounded-[10px] p-[2.5px] flex flex-col gap-[1.5px] ${t.secFld}`}
+      >
+        <StatRow label="Catches" values={stats.fielding.catches} labelClass={t.labelFld} t={t} v={v} />
+        <StatRow label="Run Outs" values={stats.fielding.runOuts} labelClass={t.labelFld} t={t} v={v} />
+        <StatRow label="Stumpings" values={stats.fielding.stumpings} labelClass={t.labelFld} t={t} v={v} />
       </div>
     </div>
-  )
-}
+  );
+};

--- a/apps/web/src/components/layout/BottomNav.tsx
+++ b/apps/web/src/components/layout/BottomNav.tsx
@@ -6,6 +6,25 @@ import { cn } from '@/lib/utils'
 
 const NAV_ITEMS = [
   {
+    href: '/',
+    label: 'Home',
+    icon: (active: boolean) => (
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill={active ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9.5z" />
+        <path d="M9 21V12h6v9" />
+      </svg>
+    ),
+  },
+  {
     href: '/collection',
     label: 'Collect',
     icon: (active: boolean) => (
@@ -110,7 +129,9 @@ export function BottomNav() {
       <div className="relative flex items-stretch">
         {NAV_ITEMS.map((item) => {
           const isActive =
-            pathname === item.href || pathname.startsWith(item.href + '/')
+            item.href === '/'
+              ? pathname === '/'
+              : pathname === item.href || pathname.startsWith(item.href + '/')
 
           return (
             <Link

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -11,9 +11,10 @@ const config: Config = {
         cream: '#fdf8f0',
       },
       fontFamily: {
-        display: ["'Bebas Neue'", 'cursive'],
-        body: ["'Inter'", 'sans-serif'],
-        supermercado: ['var(--font-supermercado)', 'cursive'],
+        display: ['var(--font-sour-gummy)', 'sans-serif'],
+        body: ['var(--font-inconsolata)', 'monospace'],
+        inconsolata: ['var(--font-inconsolata)', 'monospace'],
+        fredoka: ['var(--font-fredoka)', 'sans-serif'],
         'roboto-mono': ['var(--font-roboto-mono)', 'monospace'],
       },
       boxShadow: {


### PR DESCRIPTION
## Summary
- Replace legacy fonts: Supermercado One → Fredoka, Bebas Neue → Sour Gummy, body → Inconsolata
- Add `variant` prop to `StatsGrid` — `"card"` keeps roboto-mono at original sizes, `"page"` uses Inconsolata at compact sizes
- Add Home icon to `BottomNav` with exact-path active detection so it doesn't highlight on every route
- Fix `pointer-events-none` on hero section overlay that was blocking the Start Collecting link
- Start Collecting link now routes to `/players`

## Test plan
- [ ] Visit `/` — Start Collecting link navigates to `/players`
- [ ] Visit any page — Home icon appears in bottom nav and highlights only on `/`
- [ ] Visit `/players/:id` — StatsGrid uses Inconsolata at compact sizes
- [ ] View StatCard — StatsGrid uses roboto-mono at original sizes, card layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)