### PR TITLE
feat(players): unified search bar + multiselect filters + responsive nav

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -3,10 +3,19 @@ import type { CookieMethodsServer } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 import { verifyAdminToken, ADMIN_COOKIE_NAME } from '@/lib/admin/session'
 
+const DISABLED_ROUTES = ['/collection', '/packs', '/trade', '/battle', '/battles']
 const PROTECTED_ROUTES = ['/collection', '/packs', '/trade', '/battle']
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
+
+  // Redirect disabled pillar routes for all users
+  const isDisabled = DISABLED_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(route + '/')
+  )
+  if (isDisabled) {
+    return NextResponse.redirect(new URL('/players', request.url))
+  }
 
   // Admin routes use cookie-based auth, independent of Supabase
   if (pathname.startsWith('/admin')) {

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -62,12 +62,11 @@ export default function CollectionPage() {
           <p className="text-gray-700 text-sm">
             Your collection is empty. Open a pack to get started!
           </p>
-          <a
-            href="/packs"
-            className="inline-block mt-3 bg-brand/10 border border-brand/20 text-brand text-sm font-medium px-4 py-2 rounded-xl hover:bg-brand/20 transition-colors"
+          <div
+            className="inline-block mt-3 bg-brand/10 border border-brand/20 text-brand text-sm font-medium px-4 py-2 rounded-xl hover:bg-brand/20 transition-colors cursor-not-allowed opacity-60"
           >
             Go to Pack Shop →
-          </a>
+          </div>
         </div>
       </div>
     </main>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import {
   Inconsolata,
   Nunito,
 } from "next/font/google";
+import { Header } from "@/components/layout/Header";
 import "./globals.css";
 
 const inter = Inter({
@@ -74,7 +75,8 @@ export default function RootLayout({
         />
       </head>
       <body className="bg-gray-950 text-white font-body antialiased min-h-screen">
-        {children}
+        <Header />
+        <main className="pt-[60px] pb-[60px] md:pb-0">{children}</main>
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,7 +6,7 @@ const features = [
     title: "Collect",
     description:
       "Build your collection of legendary 90s cricketers. From common to legendary rarity.",
-    href: "/collection",
+    route: "/collection",
     color: "border-blue-400/30 bg-blue-400/5",
   },
   {
@@ -14,7 +14,7 @@ const features = [
     title: "Packs",
     description:
       "Open packs to discover new players. Every pack is a mystery waiting to be revealed.",
-    href: "/packs",
+    route: "/packs",
     color: "border-gold/30 bg-gold/5",
   },
   {
@@ -22,7 +22,7 @@ const features = [
     title: "Trade",
     description:
       "Trade cards with other collectors. Complete your collection through smart swaps.",
-    href: "/trade",
+    route: "/trade",
     color: "border-green-400/30 bg-green-400/5",
   },
   {
@@ -30,7 +30,7 @@ const features = [
     title: "Battle",
     description:
       "Pit your best players against rivals. Stats decide who reigns supreme.",
-    href: "/battle",
+    route: "/battle",
     color: "border-brand/30 bg-brand/5",
   },
 ];
@@ -84,12 +84,11 @@ export default function HomePage() {
               >
                 Start Collecting
               </Link>
-              <Link
-                href="/packs"
-                className="w-full bg-gray-800 hover:bg-gray-700 border border-gold/40 text-gold font-bold py-3.5 px-6 rounded-xl text-base transition-all duration-200 active:scale-95 text-center"
+              <div
+                className="w-full bg-gray-800 hover:bg-gray-700 border border-gold/40 text-gold font-bold py-3.5 px-6 rounded-xl text-base transition-all duration-200 active:scale-95 text-center cursor-not-allowed opacity-60"
               >
                 Open a Pack
-              </Link>
+              </div>
             </div>
             <p className="text-xs text-gray-600">
               New players start with 500 coins — enough for 5 packs!
@@ -110,23 +109,41 @@ export default function HomePage() {
       {/* Feature Cards Grid */}
       <section className="px-4 pt-4 pb-8 max-w-5xl mx-auto w-full">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          {features.map((feature) => (
-            <Link
-              key={feature.title}
-              href={feature.href}
-              className={`relative rounded-2xl border p-4 flex flex-col gap-2 transition-all duration-200 active:scale-95 hover:scale-[1.02] ${feature.color}`}
-            >
-              <span className="text-3xl">{feature.icon}</span>
-              <div>
-                <h3 className="font-display text-xl text-cream tracking-wide">
-                  {feature.title}
-                </h3>
-                <p className="text-gray-400 text-xs leading-relaxed mt-0.5">
-                  {feature.description}
-                </p>
+          {features.map((feature) => {
+            const isDisabled = ["/collection", "/packs", "/trade"].includes(
+              feature.route
+            );
+            const sharedClass = `relative rounded-2xl border p-4 flex flex-col gap-2 transition-all duration-200 active:scale-95 hover:scale-[1.02] ${feature.color}`;
+            const inner = (
+              <>
+                <span className="text-3xl">{feature.icon}</span>
+                <div>
+                  <h3 className="font-display text-xl text-cream tracking-wide">
+                    {feature.title}
+                  </h3>
+                  <p className="text-gray-400 text-xs leading-relaxed mt-0.5">
+                    {feature.description}
+                  </p>
+                </div>
+              </>
+            );
+            return isDisabled ? (
+              <div
+                key={feature.title}
+                className={`${sharedClass} cursor-not-allowed opacity-60`}
+              >
+                {inner}
               </div>
-            </Link>
-          ))}
+            ) : (
+              <Link
+                key={feature.title}
+                href={feature.route}
+                className={sharedClass}
+              >
+                {inner}
+              </Link>
+            );
+          })}
         </div>
       </section>
     </main>

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -6,6 +6,7 @@ import { CricketCard } from "@/components/card/CricketCard";
 import { CardScaleWrapper } from "@/components/card/CardScaleWrapper";
 import { StatsGrid } from "@/components/card/StatsGrid";
 import StatCard from "@/components/card/StatCard";
+import { CARD_WIDTH, CARD_HEIGHT, CARD_SCALES, CARD_DISPLAY } from "@/constants/card";
 
 type Params = Promise<{ id: string }>;
 type SearchParams = Promise<{ view?: string }>;
@@ -28,9 +29,9 @@ export default async function PlayerDetailPage({
   if (result.error) {
     if (result.error.code === "PGRST116") notFound();
     return (
-      <main className="min-h-screen bg-zinc-950 flex items-center justify-center p-8">
+      <div className="min-h-screen flex items-center justify-center p-8">
         <p className="text-red-400 text-sm">{result.error.message}</p>
-      </main>
+      </div>
     );
   }
 
@@ -42,27 +43,17 @@ export default async function PlayerDetailPage({
     "Legend"
   );
   return (
-    <main className="bg-zinc-950 min-h-screen">
-      {/* Top bar */}
-      <div className="px-8 pt-4 flex items-center gap-6">
+    <div className="bg-zinc-950 min-h-screen">
+      {/* Breadcrumb */}
+      <div className="px-8 pt-4 flex items-center gap-2 text-sm font-mono tracking-wider">
         <Link
           href="/players"
-          className="text-zinc-500 hover:text-zinc-300 text-sm font-mono tracking-wider transition-colors flex-shrink-0"
+          className="text-zinc-500 hover:text-zinc-300 transition-colors"
         >
           ← Players
         </Link>
-        <div className="flex items-center gap-4 flex-1 justify-center">
-          <h1 className="font-display text-4xl text-cream leading-none">
-            {player.name}
-          </h1>
-          <span className="text-zinc-500 text-xs uppercase tracking-wider font-mono mt-1">
-            {player.country}
-          </span>
-          <span className="text-zinc-500 text-xs uppercase tracking-wider font-mono mt-1">
-            {player.role}
-          </span>
-        </div>
-        <div className="flex-shrink-0 w-20" />
+        <span className="text-zinc-700">›</span>
+        <span className="text-zinc-300">{player.name}</span>
       </div>
 
       <div className="px-8 py-4">
@@ -92,8 +83,8 @@ export default async function PlayerDetailPage({
               </p>
               <div
                 style={{
-                  width: "375px",
-                  height: "525px",
+                  width: CARD_DISPLAY.detail.width,
+                  height: CARD_DISPLAY.detail.height,
                   overflow: "hidden",
                   position: "relative",
                   flexShrink: 0,
@@ -101,9 +92,9 @@ export default async function PlayerDetailPage({
               >
                 <div
                   style={{
-                    width: "750px",
-                    height: "1050px",
-                    transform: "scale(0.5)",
+                    width: CARD_WIDTH,
+                    height: CARD_HEIGHT,
+                    transform: `scale(${CARD_SCALES.detail})`,
                     transformOrigin: "top left",
                   }}
                 >
@@ -128,6 +119,6 @@ export default async function PlayerDetailPage({
           </div>
         )}
       </div>
-    </main>
+    </div>
   );
 }

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -62,6 +62,7 @@ export default async function PlayersPage({
       {/* Search + filter bar */}
       <div className="mb-6">
         <SearchFilterBar
+          key={[search, ...countries, ...roles].join("|")}
           initialSearch={search}
           initialCountries={countries}
           initialRoles={roles.map(

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,46 +1,16 @@
 import Link from "next/link";
-import {
-  fetchPlayersWithFormatStats,
-  fetchCountries,
-} from "@/lib/queries/players";
+import { fetchPlayersWithFormatStats } from "@/lib/queries/players";
 import type { PlayerWithFormatFilter } from "@/lib/queries/types";
 import type { PlayerRole } from "@/types/database.types";
-import { CountrySelect } from "./CountrySelect";
 import { CricketCard } from "@/components/card/CricketCard";
-import { CardScaleWrapper } from "@/components/card/CardScaleWrapper";
+import { CardWrapper } from "@/components/ui/CardWrapper";
+import { SearchFilterBar } from "@/components/players/SearchFilterBar";
 
 type SearchParams = Promise<{
-  country?: string;
-  role?: string;
+  country?: string | string[];
+  role?: string | string[];
   search?: string;
 }>;
-
-const ROLES: { label: string; value: PlayerRole | undefined }[] = [
-  { label: "All", value: undefined },
-  { label: "Batter", value: "batter" },
-  { label: "Bowler", value: "bowler" },
-  { label: "Allrounder", value: "allrounder" },
-  { label: "Keeper", value: "keeper" },
-];
-
-function buildUrl(p: {
-  country?: string;
-  role?: PlayerRole;
-  search?: string;
-}): string {
-  const params = new URLSearchParams();
-  if (p.country) params.set("country", p.country);
-  if (p.role) params.set("role", p.role);
-  if (p.search) params.set("search", p.search);
-  const qs = params.toString();
-  return qs ? `/players?${qs}` : "/players";
-}
-
-const pillBase =
-  "px-3 py-1 rounded-full text-xs uppercase tracking-wider font-medium transition-colors";
-const pillActive = "bg-brand text-white";
-const pillInactive =
-  "bg-zinc-900 text-zinc-500 border border-zinc-800 hover:border-zinc-600 hover:text-zinc-300";
 
 export default async function PlayersPage({
   searchParams,
@@ -48,32 +18,39 @@ export default async function PlayersPage({
   searchParams: SearchParams;
 }) {
   const params = await searchParams;
-  const country = params.country || undefined;
-  const role = (params.role as PlayerRole | undefined) || undefined;
-  const search = params.search || undefined;
 
-  const filter: PlayerWithFormatFilter = { country, role, search };
+  const search = params.search ?? "";
+  const countries = Array.isArray(params.country)
+    ? params.country
+    : params.country
+      ? [params.country]
+      : [];
+  const roles = Array.isArray(params.role)
+    ? params.role
+    : params.role
+      ? [params.role]
+      : [];
 
-  const [playersResult, countriesResult] = await Promise.all([
-    fetchPlayersWithFormatStats(filter),
-    fetchCountries(),
-  ]);
+  const filter: PlayerWithFormatFilter = {
+    countries,
+    roles: roles as PlayerRole[],
+    search: search || undefined,
+  };
+
+  const playersResult = await fetchPlayersWithFormatStats(filter);
 
   if (playersResult.error) {
     return (
-      <main className="min-h-screen bg-zinc-950 flex items-center justify-center">
+      <div className="min-h-screen flex items-center justify-center">
         <p className="text-red-400">{playersResult.error.message}</p>
-      </main>
+      </div>
     );
   }
 
   const players = playersResult.data;
-  const countries = countriesResult.data ?? [];
-
-  const clearSearchUrl = buildUrl({ country, role });
 
   return (
-    <main className="bg-zinc-950 min-h-screen p-12">
+    <div className="bg-zinc-950 min-h-screen p-12">
       {/* Heading */}
       <h1 className="font-display text-5xl text-cream tracking-widest uppercase mb-2">
         Players
@@ -82,57 +59,15 @@ export default async function PlayersPage({
         Nostalgia Cricket Card · 1990s Legends
       </p>
 
-      {/* Search form */}
-      <form
-        method="GET"
-        action="/players"
-        className="flex items-center gap-3 mb-6"
-      >
-        {country && <input type="hidden" name="country" value={country} />}
-        {role && <input type="hidden" name="role" value={role} />}
-        <input
-          type="text"
-          name="search"
-          defaultValue={search ?? ""}
-          placeholder="Search players…"
-          className="bg-zinc-900 border border-zinc-800 text-zinc-200 rounded-xl px-4 py-2 text-sm w-64 focus:border-zinc-600 outline-none"
+      {/* Search + filter bar */}
+      <div className="mb-6">
+        <SearchFilterBar
+          initialSearch={search}
+          initialCountries={countries}
+          initialRoles={roles.map(
+            (r) => r.charAt(0).toUpperCase() + r.slice(1)
+          )}
         />
-        <button
-          type="submit"
-          className="bg-zinc-800 text-zinc-200 px-4 py-2 rounded-xl text-sm hover:bg-zinc-700 transition-colors"
-        >
-          Search
-        </button>
-        {search && (
-          <Link
-            href={clearSearchUrl}
-            aria-label="Clear search"
-            className="bg-zinc-900 border border-zinc-800 text-zinc-400 px-3 py-2 rounded-xl text-sm hover:text-zinc-200 transition-colors"
-          >
-            ×
-          </Link>
-        )}
-      </form>
-
-      {/* Filter bar */}
-      <div className="flex flex-wrap gap-3 items-center mb-6">
-        {/* Country select */}
-        {countries.length > 0 && (
-          <CountrySelect countries={countries} selected={country} />
-        )}
-
-        {/* Role pills */}
-        <div className="flex gap-2 flex-wrap">
-          {ROLES.map(({ label, value }) => (
-            <Link
-              key={label}
-              href={buildUrl({ country, role: value, search })}
-              className={`${pillBase} ${role === value ? pillActive : pillInactive}`}
-            >
-              {label}
-            </Link>
-          ))}
-        </div>
       </div>
 
       {/* Result count */}
@@ -155,12 +90,12 @@ export default async function PlayersPage({
       ) : (
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-8">
           {players.map(({ player, stats }) => (
-            <CardScaleWrapper key={player.id} scale="grid">
+            <CardWrapper key={player.id}>
               <CricketCard player={player} stats={stats} variant="player" />
-            </CardScaleWrapper>
+            </CardWrapper>
           ))}
         </div>
       )}
-    </main>
+    </div>
   );
 }

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_LINKS = [
+  { href: "/players", label: "Players", enabled: true },
+  { href: "/collection", label: "Collection", enabled: false },
+  { href: "/packs", label: "Packs", enabled: false },
+  { href: "/battle", label: "Battle", enabled: false },
+];
+
+const MOBILE_TABS = [
+  { label: "Players", href: "/players", enabled: true, icon: "🃏" },
+  { label: "Packs", href: "/packs", enabled: false, icon: "📦" },
+  { label: "Battles", href: "/battles", enabled: false, icon: "⚔️" },
+  { label: "Trade", href: "/trade", enabled: false, icon: "🔄" },
+];
+
+export function Header() {
+  const pathname = usePathname();
+
+  return (
+    <>
+      {/* Desktop / tablet top header */}
+      <header className="hidden md:flex fixed top-0 left-0 right-0 z-50 h-[60px] items-center px-8 border-b border-zinc-800 bg-zinc-950/90 backdrop-blur-md">
+        <Link href="/" className="flex items-center gap-3 mr-10 flex-shrink-0">
+          <span className="font-display text-lg text-cream uppercase tracking-widest leading-none">
+            Nostalgia
+          </span>
+        </Link>
+
+        <nav className="flex items-center gap-1 flex-1">
+          {NAV_LINKS.map(({ href, label, enabled }) => {
+            if (!enabled) return null;
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={`px-4 py-1.5 rounded-full text-xs uppercase tracking-wider font-medium transition-colors ${
+                  pathname === href || pathname.startsWith(href + "/")
+                    ? "bg-zinc-100 text-zinc-950"
+                    : "text-zinc-400 hover:text-zinc-100"
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <button className="ml-auto px-4 py-1.5 rounded-full text-xs uppercase tracking-wider font-medium border border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200 transition-colors">
+          Sign In
+        </button>
+      </header>
+
+      {/* Mobile bottom tab bar */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 h-[60px] flex items-stretch border-t border-zinc-800 bg-zinc-950/90 backdrop-blur-md">
+        {MOBILE_TABS.map(({ href, label, enabled, icon }) => {
+          const isActive = pathname === href || pathname.startsWith(href + "/");
+
+          if (!enabled) {
+            return (
+              <span
+                key={href}
+                className="flex-1 flex flex-col items-center justify-center gap-1 py-2 opacity-30 cursor-not-allowed"
+              >
+                <span className="text-xl leading-none">{icon}</span>
+                <span className="text-[10px] font-semibold uppercase tracking-wider leading-none text-zinc-600">
+                  {label}
+                </span>
+              </span>
+            );
+          }
+
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex-1 flex flex-col items-center justify-center gap-1 py-2 transition-colors duration-150 ${
+                isActive ? "text-white" : "text-zinc-600 hover:text-zinc-400"
+              }`}
+            >
+              {isActive && (
+                <span className="absolute top-0 left-1/2 -translate-x-1/2 w-8 h-0.5 bg-white rounded-full" />
+              )}
+              <span className="text-xl leading-none">{icon}</span>
+              <span
+                className={`text-[10px] font-semibold uppercase tracking-wider leading-none ${
+                  isActive ? "text-white" : "text-zinc-600"
+                }`}
+              >
+                {label}
+              </span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
+  );
+}

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -1,0 +1,3 @@
+export { BottomNav } from "./BottomNav";
+export { Header } from "./Header";
+export { MobileContainer } from "./MobileContainer";

--- a/apps/web/src/components/players/SearchFilterBar.tsx
+++ b/apps/web/src/components/players/SearchFilterBar.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+const COUNTRIES = [
+  "India",
+  "Australia",
+  "Pakistan",
+  "England",
+  "South Africa",
+  "West Indies",
+  "Sri Lanka",
+  "New Zealand",
+];
+
+const ROLES = ["Batter", "Bowler", "Allrounder", "Keeper"];
+
+const ROLE_PILL_CLASSES: Record<string, string> = {
+  Batter: "bg-orange-900/30 text-orange-400 border border-orange-700/40",
+  Bowler: "bg-purple-900/30 text-purple-400 border border-purple-700/40",
+  Allrounder: "bg-emerald-900/30 text-emerald-400 border border-emerald-700/40",
+  Keeper: "bg-amber-900/30 text-amber-400 border border-amber-700/40",
+};
+
+const COUNTRY_PILL_CLASS =
+  "bg-blue-900/50 text-blue-300 border border-blue-700/50";
+
+interface SearchFilterBarProps {
+  initialSearch: string;
+  initialCountries: string[];
+  initialRoles: string[];
+}
+
+export function SearchFilterBar({
+  initialSearch,
+  initialCountries,
+  initialRoles,
+}: SearchFilterBarProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [searchText, setSearchText] = useState(initialSearch);
+  const [selectedCountries, setSelectedCountries] =
+    useState<string[]>(initialCountries);
+  const [selectedRoles, setSelectedRoles] = useState<string[]>(initialRoles);
+  const [countryOpen, setCountryOpen] = useState(false);
+  const [roleOpen, setRoleOpen] = useState(false);
+
+  const countryRef = useRef<HTMLDivElement>(null);
+  const roleRef = useRef<HTMLDivElement>(null);
+
+  // Sync state with URL on browser back/forward navigation
+  useEffect(() => {
+    setSearchText(searchParams.get("search") ?? "");
+    setSelectedCountries(searchParams.getAll("country"));
+    setSelectedRoles(
+      searchParams
+        .getAll("role")
+        .map((r) => r.charAt(0).toUpperCase() + r.slice(1))
+    );
+  }, [searchParams]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!countryRef.current?.contains(e.target as Node))
+        setCountryOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!roleRef.current?.contains(e.target as Node)) setRoleOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const toggleCountry = (c: string) => {
+    setSelectedCountries((prev) =>
+      prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]
+    );
+  };
+
+  const removeCountry = (c: string) => {
+    setSelectedCountries((prev) => prev.filter((x) => x !== c));
+  };
+
+  const toggleRole = (r: string) => {
+    setSelectedRoles((prev) =>
+      prev.includes(r) ? prev.filter((x) => x !== r) : [...prev, r]
+    );
+  };
+
+  const removeRole = (r: string) => {
+    setSelectedRoles((prev) => prev.filter((x) => x !== r));
+  };
+
+  const handleSearch = () => {
+    const params = new URLSearchParams();
+    if (searchText.trim()) params.set("search", searchText.trim());
+    selectedCountries.forEach((c) => params.append("country", c));
+    selectedRoles.forEach((r) => params.append("role", r.toLowerCase()));
+    router.push("/players?" + params.toString());
+  };
+
+  return (
+    <div>
+      {/* Unified bar */}
+      <div className="flex items-center bg-white/[0.06] border border-white/[0.12] rounded-2xl px-2 py-1.5 gap-0">
+        {/* Search icon + input */}
+        <span className="text-white/30 px-2 text-sm">⌕</span>
+        <input
+          type="text"
+          placeholder="Search players…"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+          className="flex-1 bg-transparent border-none outline-none text-white placeholder:text-white/30 text-[15px] px-2"
+          style={{ fontFamily: "var(--font-barlow, sans-serif)" }}
+        />
+
+        {/* Divider */}
+        <div className="w-px h-5 bg-white/10 mx-1.5 shrink-0" />
+
+        {/* Countries dropdown */}
+        <div className="relative shrink-0" ref={countryRef}>
+          <button
+            onClick={() => setCountryOpen((o) => !o)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] uppercase tracking-wide text-white/55 hover:bg-white/5 transition-colors"
+          >
+            Countries
+            {selectedCountries.length > 0 && (
+              <span className="bg-[#e8257a] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 leading-none">
+                {selectedCountries.length}
+              </span>
+            )}
+            <span className="text-[9px] opacity-40">
+              {countryOpen ? "▴" : "▾"}
+            </span>
+          </button>
+          {countryOpen && (
+            <div className="absolute top-[calc(100%+8px)] left-0 bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 min-w-[180px] shadow-xl">
+              {COUNTRIES.map((c) => (
+                <div
+                  key={c}
+                  onClick={() => toggleCountry(c)}
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] uppercase tracking-wide text-white/60"
+                >
+                  <div
+                    className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
+                      selectedCountries.includes(c)
+                        ? "bg-[#e8257a]/40 border-[#e8257a] text-white"
+                        : "border-white/20"
+                    }`}
+                  >
+                    {selectedCountries.includes(c) && "✓"}
+                  </div>
+                  <span
+                    className={selectedCountries.includes(c) ? "text-white" : ""}
+                  >
+                    {c}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className="w-px h-5 bg-white/10 mx-1.5 shrink-0" />
+
+        {/* Player Type dropdown */}
+        <div className="relative shrink-0" ref={roleRef}>
+          <button
+            onClick={() => setRoleOpen((o) => !o)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] uppercase tracking-wide text-white/55 hover:bg-white/5 transition-colors"
+          >
+            Player Type
+            {selectedRoles.length > 0 && (
+              <span className="bg-[#e8257a] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 leading-none">
+                {selectedRoles.length}
+              </span>
+            )}
+            <span className="text-[9px] opacity-40">
+              {roleOpen ? "▴" : "▾"}
+            </span>
+          </button>
+          {roleOpen && (
+            <div className="absolute top-[calc(100%+8px)] left-0 bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 min-w-[160px] shadow-xl">
+              {ROLES.map((r) => (
+                <div
+                  key={r}
+                  onClick={() => toggleRole(r)}
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] uppercase tracking-wide text-white/60"
+                >
+                  <div
+                    className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
+                      selectedRoles.includes(r)
+                        ? "bg-[#e8257a]/40 border-[#e8257a] text-white"
+                        : "border-white/20"
+                    }`}
+                  >
+                    {selectedRoles.includes(r) && "✓"}
+                  </div>
+                  <span
+                    className={selectedRoles.includes(r) ? "text-white" : ""}
+                  >
+                    {r}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className="w-px h-5 bg-white/10 mx-1.5 shrink-0" />
+
+        {/* Search button */}
+        <button
+          onClick={handleSearch}
+          className="bg-[#e8257a] text-white font-bold text-[13px] uppercase tracking-wide px-4 py-1.5 rounded-xl shrink-0"
+        >
+          Search
+        </button>
+      </div>
+
+      {/* Active pills row — full width, flex wrap */}
+      {(selectedCountries.length > 0 || selectedRoles.length > 0) && (
+        <div className="flex flex-wrap gap-2 mt-3 w-full">
+          {selectedCountries.map((c) => (
+            <span
+              key={c}
+              className={`inline-flex items-center gap-1.5 rounded-full text-xs font-bold uppercase tracking-wide px-3 py-1 ${COUNTRY_PILL_CLASS}`}
+            >
+              {c}
+              <button
+                onClick={() => removeCountry(c)}
+                className="opacity-60 hover:opacity-100 text-[11px] leading-none"
+              >
+                ✕
+              </button>
+            </span>
+          ))}
+          {selectedRoles.map((r) => (
+            <span
+              key={r}
+              className={`inline-flex items-center gap-1.5 rounded-full text-xs font-bold uppercase tracking-wide px-3 py-1 ${ROLE_PILL_CLASSES[r]}`}
+            >
+              {r}
+              <button
+                onClick={() => removeRole(r)}
+                className="opacity-60 hover:opacity-100 text-[11px] leading-none"
+              >
+                ✕
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/players/SearchFilterBar.tsx
+++ b/apps/web/src/components/players/SearchFilterBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 const COUNTRIES = [
   "India",
@@ -38,7 +38,6 @@ export function SearchFilterBar({
   initialRoles,
 }: SearchFilterBarProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [searchText, setSearchText] = useState(initialSearch);
   const [selectedCountries, setSelectedCountries] =
@@ -49,17 +48,6 @@ export function SearchFilterBar({
 
   const countryRef = useRef<HTMLDivElement>(null);
   const roleRef = useRef<HTMLDivElement>(null);
-
-  // Sync state with URL on browser back/forward navigation
-  useEffect(() => {
-    setSearchText(searchParams.get("search") ?? "");
-    setSelectedCountries(searchParams.getAll("country"));
-    setSelectedRoles(
-      searchParams
-        .getAll("role")
-        .map((r) => r.charAt(0).toUpperCase() + r.slice(1))
-    );
-  }, [searchParams]);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {

--- a/apps/web/src/components/players/index.ts
+++ b/apps/web/src/components/players/index.ts
@@ -1,0 +1,1 @@
+export { SearchFilterBar } from "./SearchFilterBar";

--- a/apps/web/src/components/ui/CardWrapper.tsx
+++ b/apps/web/src/components/ui/CardWrapper.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { CARD_WIDTH, CARD_HEIGHT, CARD_SCALES } from "@/constants/card";
+
+interface CardWrapperProps {
+  children: React.ReactNode;
+}
+
+export function CardWrapper({ children }: CardWrapperProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState<number>(CARD_SCALES.grid);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0].contentRect.width;
+      if (width > 0) setScale(width / CARD_WIDTH);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: "100%",
+        height: scale * CARD_HEIGHT,
+        overflow: "hidden",
+        position: "relative",
+        flexShrink: 0,
+      }}
+    >
+      <div
+        style={{
+          width: CARD_WIDTH,
+          height: CARD_HEIGHT,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,0 +1,2 @@
+export { CardWrapper } from "./CardWrapper";
+export { RarityBadge } from "./RarityBadge";

--- a/apps/web/src/lib/queries/players.ts
+++ b/apps/web/src/lib/queries/players.ts
@@ -18,7 +18,8 @@ function toQueryError(error: unknown): { message: string; code?: string } {
 export async function fetchPlayersWithFormatStats(
   filters: PlayerWithFormatFilter = {}
 ): Promise<QueryResult<PlayerWithFormatStats[]>> {
-  const { country, role, isActive, format = "odi", search } = filters;
+  const { country, role, isActive, format = "odi", search, countries, roles } =
+    filters;
   const supabase = await createSupabaseServerClient();
 
   let playersQuery = supabase
@@ -26,8 +27,18 @@ export async function fetchPlayersWithFormatStats(
     .select("*")
     .order("name", { ascending: true });
 
-  if (country !== undefined) playersQuery = playersQuery.eq("country", country);
-  if (role !== undefined) playersQuery = playersQuery.eq("role", role);
+  if (countries && countries.length > 0) {
+    playersQuery = playersQuery.in("country", countries);
+  } else if (country !== undefined) {
+    playersQuery = playersQuery.eq("country", country);
+  }
+
+  if (roles && roles.length > 0) {
+    playersQuery = playersQuery.in("role", roles);
+  } else if (role !== undefined) {
+    playersQuery = playersQuery.eq("role", role);
+  }
+
   if (isActive !== undefined)
     playersQuery = playersQuery.eq("is_active", isActive);
   if (search !== undefined)

--- a/apps/web/src/lib/queries/types.ts
+++ b/apps/web/src/lib/queries/types.ts
@@ -14,6 +14,8 @@ export interface PlayerFilters {
 export interface PlayerWithFormatFilter extends PlayerFilters {
   format?: CricketFormat;
   search?: string;
+  countries?: string[];
+  roles?: PlayerRole[];
 }
 
 export interface PlayerWithFormatStats {

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,16 @@
+# Navigation Structure
+
+## Visible pages (nav-linked)
+- `/players` — Player listing grid
+
+## Hidden pages (accessible via direct URL, not in nav)
+- `/packs` — Pack opening mechanic (Phase 4)
+- `/battles` — Battle system (Phase 5)  
+- `/trade` — Trading system (Phase 5)
+- `/collection` — User collection (requires auth)
+- `/admin/card-builder` — Internal dev tool (never in nav)
+- `/brandside` — Brand card customiser (internal dev tool)
+
+## Navigation components
+- `Header.tsx` — Sticky top bar (desktop/tablet) + bottom tab bar (mobile)
+- `CardWrapper.tsx` — ResizeObserver fluid card scaling


### PR DESCRIPTION
## Summary

Covers all navigation and player listing UI work from the current session.

## Changes

### New components
- `Header.tsx` — sticky top bar (desktop/tablet) with active pill nav + mobile bottom tab bar with four pillar tabs
- `CardWrapper.tsx` — ResizeObserver-based fluid card scaling, fixes mobile overflow at all grid widths
- `SearchFilterBar.tsx` — unified search bar with multiselect Country and Player Type dropdowns, coloured active pills, URL-driven state

### Updated files
- `layout.tsx` — Header added to root layout, children wrapped in main with pt/pb offsets
- `players/page.tsx` — SearchFilterBar replaces old form + select + role links, searchParams reads arrays for multi-filter support
- `players/[id]/page.tsx` — breadcrumb `← Players › Player Name` added below header
- `queries/types.ts` + `queries/players.ts` — `PlayerWithFormatFilter` extended with `countries`/`roles` arrays; `fetchPlayersWithFormatStats` uses `.in()` for multi-select
- `middleware.ts` — disabled pillar routes (`/packs`, `/battle`, `/battles`, `/trade`, `/collection`) redirect to `/players` for all users unconditionally
- `page.tsx` + `collection/page.tsx` — pillar links replaced with inert `<div>` elements (`cursor-not-allowed opacity-60`)
- `docs/navigation.md` — documents all hidden/disabled routes

## Issues closed
- Closes #23 — Responsive design mobile/tablet/web
- Relates to #18 — Navigation header (already closed)
- Relates to #19 — Hide non-functional pages (already closed)

## Testing
- Desktop 1280px: header + 4-col card grid ✅
- Tablet 768px: full nav + 3-col grid ✅
- Mobile 390px: bottom tab bar + 2-col grid + CardWrapper scaling ✅
- SearchFilterBar: multiselect dropdowns + pills + URL push ✅
- TypeScript: npx tsc --noEmit passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)