### PR TITLE
feat: remove uppercase from UI, add cva component system

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.3",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2",
         "framer-motion": "^12.38.0",
         "next": "^16.2.4",
@@ -2602,6 +2603,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/client-only": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.3",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2",
     "framer-motion": "^12.38.0",
     "next": "^16.2.4",

--- a/apps/web/src/app/battle/page.tsx
+++ b/apps/web/src/app/battle/page.tsx
@@ -34,7 +34,7 @@ export default function BattlePage() {
 
         {/* Battle mechanics preview */}
         <div className="mt-8 w-full max-w-xs text-left">
-          <h3 className="text-gray-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          <h3 className="text-gray-400 text-xs font-semibold tracking-wider mb-3">
             How Battles Work
           </h3>
           <div className="space-y-3">
@@ -68,7 +68,7 @@ export default function BattlePage() {
 
         {/* Stat match-ups preview */}
         <div className="mt-6 w-full max-w-xs bg-gray-900/60 border border-gray-800 rounded-2xl p-4">
-          <h3 className="text-gray-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          <h3 className="text-gray-400 text-xs font-semibold tracking-wider mb-3">
             Stat Match-ups
           </h3>
           <div className="space-y-2">

--- a/apps/web/src/app/card-builder/page.tsx
+++ b/apps/web/src/app/card-builder/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/card";
 import { useCountryTheme, useTitle } from "@/hooks";
 import { PageHeader } from "@/components/layout";
+import { SectionLabel, CardButton } from "@/components/ui";
 import {
   ROLE_SHOTS,
   DEFAULT_SHOT,
@@ -76,7 +77,7 @@ function ColorField({ label, value, onChange, tabIndex }: ColorFieldProps) {
         }}
         className="w-10 h-10 rounded-lg cursor-pointer border-0 bg-transparent"
       />
-      <span className="text-zinc-400 text-xs uppercase tracking-widest w-28 flex-shrink-0">
+      <span className="text-zinc-400 text-xs tracking-widest w-28 flex-shrink-0">
         {label}
       </span>
       <div className="flex items-center flex-1 bg-zinc-800 rounded-xl px-3 py-2 gap-1">
@@ -89,7 +90,7 @@ function ColorField({ label, value, onChange, tabIndex }: ColorFieldProps) {
           onChange={(e) => setHex(`#${e.target.value}`)}
           onBlur={commit}
           onKeyDown={(e) => e.key === "Enter" && commit()}
-          className="flex-1 bg-transparent text-sm font-mono uppercase text-white focus:outline-none"
+          className="flex-1 bg-transparent text-sm font-mono text-white focus:outline-none"
         />
       </div>
       <div
@@ -147,7 +148,7 @@ function CardBuilderPageInner() {
         title="Card Builder"
         subtitle={
           <>
-            <span className="font-display text-sm uppercase tracking-widest text-white flex-shrink-0">
+            <span className="font-display text-sm tracking-widest text-white flex-shrink-0">
               {selectedCountry}
             </span>
             <span className="text-zinc-500 text-xs font-mono ml-3 tracking-wide">
@@ -158,7 +159,7 @@ function CardBuilderPageInner() {
         right={
           <button
             onClick={() => setEditMode((m) => (m === "form" ? "tap" : "form"))}
-            className={`px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-widest transition-all ${
+            className={`px-4 py-1.5 rounded-full text-xs font-bold tracking-widest transition-all ${
               editMode === "tap"
                 ? "bg-pink-500 text-white"
                 : "border border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
@@ -203,7 +204,7 @@ function CardBuilderPageInner() {
                 <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}
-                  className={`flex-1 py-2 rounded-xl text-xs uppercase tracking-widest font-bold transition-all ${
+                  className={`flex-1 py-2 rounded-xl text-xs tracking-widest font-bold transition-all ${
                     activeTab === tab
                       ? "bg-pink-500 text-white"
                       : "text-zinc-400 hover:text-zinc-200"
@@ -248,14 +249,14 @@ function CardBuilderPageInner() {
             {activeTab === "character" && (
               <div className="flex flex-col gap-4">
                 {/* Role selector */}
-                <p className="text-zinc-400 text-xs uppercase tracking-widest">Role</p>
+                <SectionLabel>Role</SectionLabel>
                 <div className="grid grid-cols-4 gap-2">
                   {(["batter", "bowler", "allrounder", "keeper"] as PlayerRole[]).map((role, i) => (
                     <button
                       key={role}
                       tabIndex={5 + i}
                       onClick={() => handleRoleChange(role)}
-                      className={`py-2 rounded-xl text-xs uppercase tracking-widest font-bold transition-all ${
+                      className={`py-2 rounded-xl text-xs tracking-widest font-bold transition-all ${
                         selectedRole === role
                           ? "bg-pink-500 text-white"
                           : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
@@ -267,13 +268,13 @@ function CardBuilderPageInner() {
                 </div>
 
                 {/* Shot selector */}
-                <p className="text-zinc-400 text-xs uppercase tracking-widest mt-2">Shot</p>
+                <SectionLabel className="mt-2">Shot</SectionLabel>
                 <div className="grid grid-cols-3 gap-2">
                   {ROLE_SHOTS[selectedRole].map((shot) => (
                     <button
                       key={shot}
                       onClick={() => setSelectedShot(shot)}
-                      className={`py-2 rounded-xl text-xs uppercase tracking-widest font-bold transition-all ${
+                      className={`py-2 rounded-xl text-xs tracking-widest font-bold transition-all ${
                         selectedShot === shot
                           ? "bg-yellow-400 text-zinc-900"
                           : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
@@ -322,7 +323,8 @@ function CardBuilderPageInner() {
                   tabIndex={21}
                   className="w-full bg-zinc-800 rounded-xl px-4 py-3 text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-pink-400"
                 />
-                <button
+                <CardButton
+                  variant="primary"
                   tabIndex={22}
                   onClick={() =>
                     save({
@@ -332,17 +334,16 @@ function CardBuilderPageInner() {
                       savedAt: "",
                     })
                   }
-                  className="w-full bg-pink-500 hover:bg-pink-600 text-white font-bold py-3 rounded-xl uppercase tracking-widest transition-all"
                 >
                   Save & Apply to {selectedCountry}
-                </button>
-                <button
+                </CardButton>
+                <CardButton
+                  variant="secondary"
                   tabIndex={23}
                   onClick={reset}
-                  className="w-full bg-zinc-800 hover:bg-zinc-700 text-zinc-400 font-bold py-3 rounded-xl uppercase tracking-widest transition-all"
                 >
                   Reset to Default
-                </button>
+                </CardButton>
               </div>
             )}
           </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function HomePage() {
           {/* Heading block */}
           <div className="flex flex-col items-center lg:items-start">
             <div className="mb-4">
-              <span className="inline-block bg-brand text-white text-xs font-bold tracking-widest uppercase px-3 py-1 rounded-full">
+              <span className="inline-block bg-brand text-white text-xs font-bold tracking-widest px-3 py-1 rounded-full">
                 Est. 1990s
               </span>
             </div>
@@ -100,7 +100,7 @@ export default function HomePage() {
       {/* Divider */}
       <div className="flex items-center gap-3 px-6 py-2 max-w-5xl mx-auto w-full">
         <div className="flex-1 h-px bg-gray-800" />
-        <span className="text-gray-600 text-xs font-medium uppercase tracking-widest">
+        <span className="text-gray-600 text-xs font-medium tracking-widest">
           Four Pillars
         </span>
         <div className="flex-1 h-px bg-gray-800" />

--- a/apps/web/src/app/players/CountrySelect.tsx
+++ b/apps/web/src/app/players/CountrySelect.tsx
@@ -25,7 +25,7 @@ export function CountrySelect({ countries, selected }: CountrySelectProps) {
     <select
       value={selected ?? ""}
       onChange={handleChange}
-      className="bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg px-3 py-2 text-xs uppercase tracking-wider cursor-pointer focus:outline-none focus:border-zinc-500"
+      className="bg-zinc-900 border border-zinc-700 text-zinc-300 rounded-lg px-3 py-2 text-xs tracking-wider cursor-pointer focus:outline-none focus:border-zinc-500"
     >
       <option value="">All Countries</option>
       {countries.map((c) => (

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -54,13 +54,13 @@ export default async function PlayerDetailPage({
         title={player.name}
         subtitle={
           <>
-            <span className="font-display text-sm uppercase tracking-widest text-white">
+            <span className="font-display text-sm tracking-widest text-white">
               {player.country}
             </span>
             <span className="mx-2 flex-shrink-0 text-pink-400 font-bold">
               ›
             </span>
-            <span className="font-display text-sm uppercase tracking-widest text-white">
+            <span className="font-display text-sm tracking-widest text-white">
               {player.role}
             </span>
           </>
@@ -74,7 +74,7 @@ export default async function PlayerDetailPage({
             <Link
               key={v}
               href={`/players/${player.id}?view=${v}`}
-              className={`px-5 py-2 rounded-full text-xs uppercase tracking-wider font-medium transition-colors ${
+              className={`px-5 py-2 rounded-full text-xs tracking-wider font-medium transition-colors ${
                 view === v
                   ? "bg-zinc-100 text-zinc-950"
                   : "text-zinc-500 border border-zinc-800 hover:border-zinc-600"
@@ -89,7 +89,7 @@ export default async function PlayerDetailPage({
         {view === "card" ? (
           <div className="flex flex-wrap gap-8 justify-center">
             <div className="flex flex-col items-center gap-3">
-              <p className="text-zinc-600 text-[10px] uppercase tracking-widest font-mono">
+              <p className="text-zinc-600 text-[10px] tracking-widest font-mono">
                 Stat Card
               </p>
               <div
@@ -117,7 +117,7 @@ export default async function PlayerDetailPage({
               href={`/card-builder?country=${encodeURIComponent(player.country)}&role=${player.role}`}
               className="flex flex-col items-center gap-3 group cursor-pointer"
             >
-              <p className="text-zinc-600 text-[10px] uppercase tracking-widest font-mono group-hover:text-pink-400 transition-colors">
+              <p className="text-zinc-600 text-[10px] tracking-widest font-mono group-hover:text-pink-400 transition-colors">
                 Brand Card ↗
               </p>
               <CardScaleWrapper scale="detail">

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -77,7 +77,7 @@ export default async function PlayersPage({
           <p>No players found.</p>
           <Link
             href="/players"
-            className="text-xs uppercase tracking-wider border border-zinc-800 px-4 py-2 rounded-full hover:border-zinc-600 hover:text-zinc-400 transition-colors"
+            className="text-xs tracking-wider border border-zinc-800 px-4 py-2 rounded-full hover:border-zinc-600 hover:text-zinc-400 transition-colors"
           >
             Reset filters
           </Link>

--- a/apps/web/src/app/stat-side/page.tsx
+++ b/apps/web/src/app/stat-side/page.tsx
@@ -43,10 +43,10 @@ export default function StatSidePage() {
   return (
     <main className="min-h-screen bg-[#0a0f1e] flex flex-col items-center justify-center p-8 gap-8">
       <div className="text-center mb-4">
-        <h1 className="text-white text-3xl font-bold tracking-tight mb-2 uppercase font-mono">
+        <h1 className="text-white text-3xl font-bold tracking-tight mb-2 font-mono">
           Stat Side Preview
         </h1>
-        <p className="text-zinc-500 text-sm uppercase tracking-[0.3em] font-mono">
+        <p className="text-zinc-500 text-sm tracking-[0.3em] font-mono">
           HTML v7 → React Conversion
         </p>
       </div>

--- a/apps/web/src/app/trade/page.tsx
+++ b/apps/web/src/app/trade/page.tsx
@@ -48,7 +48,7 @@ export default function TradePage() {
 
         {/* How trading works */}
         <div className="mt-8 w-full max-w-xs text-left">
-          <h3 className="text-gray-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          <h3 className="text-gray-400 text-xs font-semibold tracking-wider mb-3">
             How Trading Works
           </h3>
           <div className="space-y-3">

--- a/apps/web/src/components/card/CharacterHotspotOverlay.tsx
+++ b/apps/web/src/components/card/CharacterHotspotOverlay.tsx
@@ -54,7 +54,7 @@ function ColorPopover({ label, value, onChange, onClose, anchorStyle }: ColorPop
       className="absolute z-50 bg-white rounded-2xl shadow-2xl p-4 flex flex-col gap-3 min-w-[200px]"
       style={anchorStyle}
     >
-      <p className="font-display text-sm uppercase tracking-widest text-zinc-500">{label}</p>
+      <p className="font-display text-sm tracking-widest text-zinc-500">{label}</p>
       <input
         type="color"
         value={hex.startsWith("#") && hex.length === 7 ? hex : "#000000"}

--- a/apps/web/src/components/layout/BottomNav.tsx
+++ b/apps/web/src/components/layout/BottomNav.tsx
@@ -153,7 +153,7 @@ export function BottomNav() {
 
               <span
                 className={cn(
-                  "text-[10px] font-semibold uppercase tracking-wider leading-none",
+                  "text-[10px] font-semibold tracking-wider leading-none",
                   isActive ? "text-brand" : "text-gray-600"
                 )}
               >

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -33,7 +33,7 @@ export function Header() {
         }}
       >
         <Link href="/" className="flex items-center gap-3 mr-10 flex-shrink-0">
-          <span className="font-display text-lg text-cream uppercase tracking-widest text-pink-400 leading-none">
+          <span className="font-display text-lg text-cream tracking-widest text-pink-400 leading-none">
             Nostalgia
           </span>
         </Link>
@@ -45,7 +45,7 @@ export function Header() {
               <Link
                 key={href}
                 href={href}
-                className={`relative px-4 py-1.5 text-xs uppercase tracking-wider font-medium transition-colors ${
+                className={`relative px-4 py-1.5 text-xs tracking-wider font-medium transition-colors ${
                   pathname === href || pathname.startsWith(href + "/")
                     ? "text-white after:absolute after:bottom-[-17px] after:left-0 after:right-0 after:h-[2px] after:bg-[#e8257a] after:rounded-full"
                     : "text-zinc-400 hover:text-zinc-100"
@@ -57,7 +57,7 @@ export function Header() {
           })}
         </nav>
 
-        <button className="ml-auto px-4 py-1.5 text-xs uppercase tracking-wider font-bold text-pink-500 hover:text-zinc-200 transition-colors">
+        <button className="ml-auto px-4 py-1.5 text-xs tracking-wider font-bold text-pink-500 hover:text-zinc-200 transition-colors">
           Sign In
         </button>
       </header>
@@ -74,7 +74,7 @@ export function Header() {
                 className="flex-1 flex flex-col items-center justify-center gap-1 py-2 opacity-30 cursor-not-allowed"
               >
                 <span className="text-xl leading-none">{icon}</span>
-                <span className="text-[10px] font-semibold uppercase tracking-wider leading-none text-zinc-600">
+                <span className="text-[10px] font-semibold tracking-wider leading-none text-zinc-600">
                   {label}
                 </span>
               </span>
@@ -94,7 +94,7 @@ export function Header() {
               )}
               <span className="text-xl leading-none">{icon}</span>
               <span
-                className={`text-[10px] font-semibold uppercase tracking-wider leading-none ${
+                className={`text-[10px] font-semibold tracking-wider leading-none ${
                   isActive ? "text-white" : "text-zinc-600"
                 }`}
               >

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -18,14 +18,12 @@ export function PageHeader({
 }: PageHeaderProps) {
   usePageHeaderContent(
     <div className="flex items-center w-full">
-      <span className="font-display text-sm uppercase tracking-widest flex-shrink-0">
+      <span className="font-display text-sm tracking-widest flex-shrink-0">
         {title}
       </span>
       {subtitle != null && (
         <>
-          <span className="mx-2 flex-shrink-0 text-pink-400 font-bold">
-            ›
-          </span>
+          <span className="mx-2 flex-shrink-0 text-pink-400 font-bold">›</span>
           {subtitleFill ? (
             <div className="flex-1 min-w-0">{subtitle}</div>
           ) : (

--- a/apps/web/src/components/players/SearchFilterBar.tsx
+++ b/apps/web/src/components/players/SearchFilterBar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { RoleBadge } from "@/components/ui";
 
 const COUNTRIES = [
   "India",
@@ -16,15 +17,6 @@ const COUNTRIES = [
 
 const ROLES = ["Batter", "Bowler", "Allrounder", "Keeper"];
 
-const ROLE_PILL_CLASSES: Record<string, string> = {
-  Batter: "bg-orange-900/30 text-orange-400 border border-orange-700/40",
-  Bowler: "bg-purple-900/30 text-purple-400 border border-purple-700/40",
-  Allrounder: "bg-emerald-900/30 text-emerald-400 border border-emerald-700/40",
-  Keeper: "bg-amber-900/30 text-amber-400 border border-amber-700/40",
-};
-
-const COUNTRY_PILL_CLASS =
-  "bg-blue-900/50 text-blue-300 border border-blue-700/50";
 
 interface SearchFilterBarProps {
   initialSearch: string;
@@ -121,7 +113,7 @@ export function SearchFilterBar({
         <div className="relative shrink-0" ref={countryRef}>
           <button
             onClick={() => setCountryOpen((o) => !o)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] uppercase tracking-wide text-white/55 hover:bg-white/5 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] tracking-wide text-white/55 hover:bg-white/5 transition-colors"
           >
             Countries
             {selectedCountries.length > 0 && (
@@ -137,7 +129,7 @@ export function SearchFilterBar({
             <div className="absolute top-[calc(100%+8px)] left-0 bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 min-w-[180px] shadow-xl">
               <div
                 onClick={() => setSelectedCountries([])}
-                className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] uppercase tracking-wide border-b border-white/5 mb-1"
+                className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide border-b border-white/5 mb-1"
               >
                 <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 ${
                   selectedCountries.length === 0 ? "bg-[#e8257a]/40 border-[#e8257a] text-white" : "border-white/20"
@@ -150,7 +142,7 @@ export function SearchFilterBar({
                 <div
                   key={c}
                   onClick={() => toggleCountry(c)}
-                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] uppercase tracking-wide text-white/60"
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide text-white/60"
                 >
                   <div
                     className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
@@ -179,7 +171,7 @@ export function SearchFilterBar({
         <div className="relative shrink-0" ref={roleRef}>
           <button
             onClick={() => setRoleOpen((o) => !o)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] uppercase tracking-wide text-white/55 hover:bg-white/5 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] tracking-wide text-white/55 hover:bg-white/5 transition-colors"
           >
             Player Type
             {selectedRoles.length > 0 && (
@@ -195,7 +187,7 @@ export function SearchFilterBar({
             <div className="absolute top-[calc(100%+8px)] left-0 bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 min-w-[160px] shadow-xl">
               <div
                 onClick={() => setSelectedRoles([])}
-                className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] uppercase tracking-wide border-b border-white/5 mb-1"
+                className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide border-b border-white/5 mb-1"
               >
                 <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 ${
                   selectedRoles.length === 0 ? "bg-[#e8257a]/40 border-[#e8257a] text-white" : "border-white/20"
@@ -208,7 +200,7 @@ export function SearchFilterBar({
                 <div
                   key={r}
                   onClick={() => toggleRole(r)}
-                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] uppercase tracking-wide text-white/60"
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide text-white/60"
                 >
                   <div
                     className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
@@ -236,7 +228,7 @@ export function SearchFilterBar({
         {/* Search button */}
         <button
           onClick={handleSearch}
-          className="bg-[#e8257a] text-white font-bold text-[13px] uppercase tracking-wide px-4 py-1.5 rounded-xl shrink-0"
+          className="bg-[#e8257a] text-white font-bold text-[13px] tracking-wide px-4 py-1.5 rounded-xl shrink-0"
         >
           Search
         </button>
@@ -249,7 +241,7 @@ export function SearchFilterBar({
             <span
               key={c}
               onClick={() => toggleCountry(c)}
-              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold uppercase tracking-wide px-3 py-1 cursor-pointer bg-zinc-800/60 text-zinc-500 border border-zinc-700/40 hover:text-zinc-300 hover:border-zinc-600 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold tracking-wide px-3 py-1 cursor-pointer bg-zinc-800/60 text-zinc-500 border border-zinc-700/40 hover:text-zinc-300 hover:border-zinc-600 transition-colors"
             >
               {c}
             </span>
@@ -258,7 +250,7 @@ export function SearchFilterBar({
           selectedCountries.map((c) => (
             <span
               key={c}
-              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold uppercase tracking-wide px-3 py-1 bg-blue-900/50 text-blue-300 border border-blue-700/50"
+              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold tracking-wide px-3 py-1 bg-blue-900/50 text-blue-300 border border-blue-700/50"
             >
               {c}
               <button
@@ -278,16 +270,16 @@ export function SearchFilterBar({
             <span
               key={r}
               onClick={() => toggleRole(r)}
-              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold uppercase tracking-wide px-3 py-1 cursor-pointer bg-zinc-800/60 text-zinc-500 border border-zinc-700/40 hover:text-zinc-300 hover:border-zinc-600 transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold tracking-wide px-3 py-1 cursor-pointer bg-zinc-800/60 text-zinc-500 border border-zinc-700/40 hover:text-zinc-300 hover:border-zinc-600 transition-colors"
             >
               {r}
             </span>
           ))
         ) : (
           selectedRoles.map((r) => (
-            <span
+            <RoleBadge
               key={r}
-              className={`inline-flex items-center gap-1.5 rounded-full text-xs font-bold uppercase tracking-wide px-3 py-1 ${ROLE_PILL_CLASSES[r]}`}
+              role={r.toLowerCase() as "batter" | "bowler" | "allrounder" | "keeper"}
             >
               {r}
               <button
@@ -296,7 +288,7 @@ export function SearchFilterBar({
               >
                 ✕
               </button>
-            </span>
+            </RoleBadge>
           ))
         )}
       </div>

--- a/apps/web/src/components/ui/CardButton.tsx
+++ b/apps/web/src/components/ui/CardButton.tsx
@@ -1,0 +1,41 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { type ReactNode } from "react";
+
+const cardButton = cva(
+  "w-full font-bold py-3 rounded-xl tracking-widest transition-all",
+  {
+    variants: {
+      variant: {
+        primary: "bg-pink-500 hover:bg-pink-600 text-white",
+        secondary: "bg-zinc-800 hover:bg-zinc-700 text-zinc-400",
+      },
+    },
+  }
+);
+
+interface CardButtonProps extends VariantProps<typeof cardButton> {
+  variant: "primary" | "secondary";
+  onClick?: () => void;
+  children: ReactNode;
+  disabled?: boolean;
+  tabIndex?: number;
+}
+
+export function CardButton({
+  variant,
+  onClick,
+  children,
+  disabled,
+  tabIndex,
+}: CardButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      tabIndex={tabIndex}
+      className={cardButton({ variant })}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/FormatPill.tsx
+++ b/apps/web/src/components/ui/FormatPill.tsx
@@ -1,0 +1,29 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const formatPill = cva(
+  "inline-flex items-center rounded-full text-xs font-bold tracking-wide px-3 py-1",
+  {
+    variants: {
+      format: {
+        test: "bg-amber-900/40 text-amber-200",
+        odi: "bg-blue-900/50 text-blue-300",
+        t20i: "bg-pink-900/50 text-pink-300",
+      },
+    },
+  }
+);
+
+interface FormatPillProps extends VariantProps<typeof formatPill> {
+  format: "test" | "odi" | "t20i";
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function FormatPill({ format, children, className }: FormatPillProps) {
+  return (
+    <span className={cn(formatPill({ format }), className)}>
+      {children ?? format.toUpperCase()}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/RarityBadge.tsx
+++ b/apps/web/src/components/ui/RarityBadge.tsx
@@ -1,31 +1,34 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 import type { Rarity } from "@/types";
 
-interface RarityBadgeProps {
-  rarity: Rarity;
-  size?: "xs" | "sm" | "md";
-  showDot?: boolean;
-  className?: string;
-}
+const rarityBadge = cva(
+  "inline-flex items-center font-bold tracking-widest rounded-full",
+  {
+    variants: {
+      rarity: {
+        common: "bg-gray-800 text-gray-300 border border-gray-600",
+        uncommon: "bg-green-900/40 text-green-300 border border-green-700/60",
+        rare: "bg-blue-900/40 text-blue-300 border border-blue-700/60",
+        legendary: "bg-yellow-900/40 text-yellow-300 border border-yellow-600/60",
+      },
+      size: {
+        xs: "text-[9px] px-1.5 py-0.5 gap-1",
+        sm: "text-[11px] px-2 py-0.5 gap-1",
+        md: "text-xs px-2.5 py-1 gap-1.5",
+      },
+    },
+    defaultVariants: {
+      size: "sm",
+    },
+  }
+);
 
-const RARITY_STYLES: Record<Rarity, string> = {
-  common: "bg-gray-800 text-gray-300 border border-gray-600",
-  uncommon: "bg-green-900/40 text-green-300 border border-green-700/60",
-  rare: "bg-blue-900/40 text-blue-300 border border-blue-700/60",
-  legendary: "bg-yellow-900/40 text-yellow-300 border border-yellow-600/60",
-};
-
-const RARITY_DOT: Record<Rarity, string> = {
+const DOT_COLORS: Record<Rarity, string> = {
   common: "bg-gray-400",
   uncommon: "bg-green-400",
   rare: "bg-blue-400",
   legendary: "bg-yellow-400",
-};
-
-const SIZE_STYLES = {
-  xs: "text-[9px] px-1.5 py-0.5 gap-1",
-  sm: "text-[11px] px-2 py-0.5 gap-1",
-  md: "text-xs px-2.5 py-1 gap-1.5",
 };
 
 const DOT_SIZES = {
@@ -34,6 +37,12 @@ const DOT_SIZES = {
   md: "w-2 h-2",
 };
 
+interface RarityBadgeProps extends VariantProps<typeof rarityBadge> {
+  rarity: Rarity;
+  showDot?: boolean;
+  className?: string;
+}
+
 export function RarityBadge({
   rarity,
   size = "sm",
@@ -41,20 +50,13 @@ export function RarityBadge({
   className,
 }: RarityBadgeProps) {
   return (
-    <span
-      className={cn(
-        "inline-flex items-center font-bold uppercase tracking-widest rounded-full",
-        RARITY_STYLES[rarity],
-        SIZE_STYLES[size],
-        className
-      )}
-    >
+    <span className={cn(rarityBadge({ rarity, size }), className)}>
       {showDot && (
         <span
           className={cn(
             "rounded-full flex-shrink-0",
-            RARITY_DOT[rarity],
-            DOT_SIZES[size]
+            DOT_COLORS[rarity],
+            DOT_SIZES[size ?? "sm"]
           )}
         />
       )}

--- a/apps/web/src/components/ui/RoleBadge.tsx
+++ b/apps/web/src/components/ui/RoleBadge.tsx
@@ -1,0 +1,33 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+import { type ReactNode } from "react";
+
+const roleBadge = cva(
+  "inline-flex items-center gap-1.5 rounded-full text-xs font-bold tracking-wide px-3 py-1",
+  {
+    variants: {
+      role: {
+        batter: "bg-orange-900/30 text-orange-400 border border-orange-700/40",
+        bowler: "bg-purple-900/30 text-purple-400 border border-purple-700/40",
+        allrounder: "bg-emerald-900/30 text-emerald-400 border border-emerald-700/40",
+        keeper: "bg-amber-900/30 text-amber-400 border border-amber-700/40",
+      },
+    },
+  }
+);
+
+type RoleKey = "batter" | "bowler" | "allrounder" | "keeper";
+
+interface RoleBadgeProps extends VariantProps<typeof roleBadge> {
+  role: RoleKey;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function RoleBadge({ role, children, className }: RoleBadgeProps) {
+  return (
+    <span className={cn(roleBadge({ role }), className)}>
+      {children ?? role}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/SectionLabel.tsx
+++ b/apps/web/src/components/ui/SectionLabel.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+import { type ReactNode } from "react";
+
+interface SectionLabelProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function SectionLabel({ children, className }: SectionLabelProps) {
+  return (
+    <p className={cn("text-zinc-400 text-xs tracking-widest", className)}>
+      {children}
+    </p>
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,2 +1,6 @@
+export { CardButton } from "./CardButton";
 export { CardWrapper } from "./CardWrapper";
+export { FormatPill } from "./FormatPill";
 export { RarityBadge } from "./RarityBadge";
+export { RoleBadge } from "./RoleBadge";
+export { SectionLabel } from "./SectionLabel";


### PR DESCRIPTION
## What this PR does
- Removes uppercase Tailwind class from all UI components
- Keeps uppercase intentionally on card face and hex input
- Introduces cva for component variants
- Adds FormatPill, RoleBadge, SectionLabel, CardButton to components/ui/

## What's NOT in this PR
- Font pairing (criterion 2) — coming in a follow-up commit on the same branch

Closes #16 (partial)