### PR TITLE
feat(player-detail): move view toggle to PageHeader right slot

### DIFF
--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -65,25 +65,26 @@ export default async function PlayerDetailPage({
             </span>
           </>
         }
+        right={
+          <div className="flex gap-1 bg-zinc-900 rounded-full p-1">
+            {(["card", "table"] as const).map((v) => (
+              <Link
+                key={v}
+                href={`/players/${player.id}?view=${v}`}
+                className={`px-4 py-1.5 rounded-full text-xs font-bold tracking-widest transition-all ${
+                  view === v
+                    ? "bg-zinc-100 text-zinc-950"
+                    : "text-zinc-400 hover:text-zinc-200"
+                }`}
+              >
+                {v === "card" ? "Card View" : "Table View"}
+              </Link>
+            ))}
+          </div>
+        }
       />
 
       <div className="px-8 py-4">
-        {/* View tabs */}
-        <div className="flex gap-2 mb-4 justify-center mt-2">
-          {(["card", "table"] as const).map((v) => (
-            <Link
-              key={v}
-              href={`/players/${player.id}?view=${v}`}
-              className={`px-5 py-2 rounded-full text-xs tracking-wider font-medium transition-colors ${
-                view === v
-                  ? "bg-zinc-100 text-zinc-950"
-                  : "text-zinc-500 border border-zinc-800 hover:border-zinc-600"
-              }`}
-            >
-              {v === "card" ? "Card View" : "Table View"}
-            </Link>
-          ))}
-        </div>
 
         {/* Content */}
         {view === "card" ? (


### PR DESCRIPTION
## What
Moves the Card View / Table View toggle on `/players/[id]` out of the page body and into the `PageHeader` `right` prop.

## Why
Consistent with the Form Mode / Tap Mode toggle pattern on the Card Builder page. Cleans up vertical space above card/table content.

## How
- Removed the `flex gap-2 mb-4 justify-center` div from the body
- Passed a pill-group `<div>` with two `<Link>` elements as `right` to `<PageHeader>`
- No behaviour change — still uses `?view=` search params, still a server component

## Checklist
- [ ] Toggle appears in header bar flush right
- [ ] Active state highlights correctly on both Card View and Table View
- [ ] URL param persists on navigation