### PR TITLE
feat(ui): Select, MultiSelect, and TabSwitch components

### DIFF
--- a/apps/web/src/app/card-builder/page.tsx
+++ b/apps/web/src/app/card-builder/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/card";
 import { useCountryTheme, useTitle } from "@/hooks";
 import { PageHeader } from "@/components/layout";
-import { SectionLabel, CardButton } from "@/components/ui";
+import { SectionLabel, CardButton, Select } from "@/components/ui";
 import {
   ROLE_SHOTS,
   DEFAULT_SHOT,
@@ -323,18 +323,12 @@ function CardBuilderPageInner() {
             {/* Tab: Presets */}
             {activeTab === "presets" && (
               <div className="flex flex-col gap-4">
-                <select
+                <Select
+                  options={COUNTRIES}
                   value={selectedCountry}
-                  onChange={(e) => setSelectedCountry(e.target.value)}
-                  tabIndex={20}
-                  className="w-full bg-zinc-800 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-pink-400"
-                >
-                  {COUNTRIES.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
+                  onChange={setSelectedCountry}
+                  className="w-full"
+                />
                 <input
                   type="text"
                   placeholder="Preset name..."

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -35,7 +35,7 @@ export default async function PlayersPage({
   const filter: PlayerWithFormatFilter = {
     countries,
     roles: roles as PlayerRole[],
-    search: search || undefined,
+    search: typeof search === "string" ? search || undefined : undefined,
   };
 
   const playersResult = await fetchPlayersWithFormatStats(filter);

--- a/apps/web/src/components/players/SearchFilterBar.tsx
+++ b/apps/web/src/components/players/SearchFilterBar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { RoleBadge } from "@/components/ui";
+import { RoleBadge, MultiSelect } from "@/components/ui";
 
 const COUNTRIES = [
   "India",
@@ -35,28 +35,7 @@ export function SearchFilterBar({
   const [selectedCountries, setSelectedCountries] =
     useState<string[]>(initialCountries);
   const [selectedRoles, setSelectedRoles] = useState<string[]>(initialRoles);
-  const [countryOpen, setCountryOpen] = useState(false);
-  const [roleOpen, setRoleOpen] = useState(false);
 
-  const countryRef = useRef<HTMLDivElement>(null);
-  const roleRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (!countryRef.current?.contains(e.target as Node))
-        setCountryOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (!roleRef.current?.contains(e.target as Node)) setRoleOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
 
   const toggleCountry = (c: string) => {
     setSelectedCountries((prev) => {
@@ -110,117 +89,25 @@ export function SearchFilterBar({
         <div className="w-px h-5 bg-white/10 mx-1.5 shrink-0" />
 
         {/* Countries dropdown */}
-        <div className="relative shrink-0" ref={countryRef}>
-          <button
-            onClick={() => setCountryOpen((o) => !o)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] tracking-wide text-white/55 hover:bg-white/5 transition-colors"
-          >
-            Countries
-            {selectedCountries.length > 0 && (
-              <span className="bg-[#e8257a] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 leading-none">
-                {selectedCountries.length}
-              </span>
-            )}
-            <span className="text-[9px] opacity-40">
-              {countryOpen ? "▴" : "▾"}
-            </span>
-          </button>
-          {countryOpen && (
-            <div className="absolute top-[calc(100%+8px)] left-0 bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 min-w-[180px] shadow-xl">
-              <div
-                onClick={() => setSelectedCountries([])}
-                className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide border-b border-white/5 mb-1"
-              >
-                <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 ${
-                  selectedCountries.length === 0 ? "bg-[#e8257a]/40 border-[#e8257a] text-white" : "border-white/20"
-                }`}>
-                  {selectedCountries.length === 0 && "✓"}
-                </div>
-                <span className={selectedCountries.length === 0 ? "text-white" : "text-white/60"}>All Countries</span>
-              </div>
-              {COUNTRIES.map((c) => (
-                <div
-                  key={c}
-                  onClick={() => toggleCountry(c)}
-                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide text-white/60"
-                >
-                  <div
-                    className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
-                      selectedCountries.includes(c)
-                        ? "bg-[#e8257a]/40 border-[#e8257a] text-white"
-                        : "border-white/20"
-                    }`}
-                  >
-                    {selectedCountries.includes(c) && "✓"}
-                  </div>
-                  <span
-                    className={selectedCountries.includes(c) ? "text-white" : ""}
-                  >
-                    {c}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        <MultiSelect
+          label="Countries"
+          options={COUNTRIES}
+          selected={selectedCountries}
+          onChange={setSelectedCountries}
+          allLabel="All Countries"
+        />
 
         {/* Divider */}
         <div className="w-px h-5 bg-white/10 mx-1.5 shrink-0" />
 
         {/* Player Type dropdown */}
-        <div className="relative shrink-0" ref={roleRef}>
-          <button
-            onClick={() => setRoleOpen((o) => !o)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] tracking-wide text-white/55 hover:bg-white/5 transition-colors"
-          >
-            Player Type
-            {selectedRoles.length > 0 && (
-              <span className="bg-[#e8257a] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 leading-none">
-                {selectedRoles.length}
-              </span>
-            )}
-            <span className="text-[9px] opacity-40">
-              {roleOpen ? "▴" : "▾"}
-            </span>
-          </button>
-          {roleOpen && (
-            <div className="absolute top-[calc(100%+8px)] left-0 bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 min-w-[160px] shadow-xl">
-              <div
-                onClick={() => setSelectedRoles([])}
-                className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide border-b border-white/5 mb-1"
-              >
-                <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 ${
-                  selectedRoles.length === 0 ? "bg-[#e8257a]/40 border-[#e8257a] text-white" : "border-white/20"
-                }`}>
-                  {selectedRoles.length === 0 && "✓"}
-                </div>
-                <span className={selectedRoles.length === 0 ? "text-white" : "text-white/60"}>All Roles</span>
-              </div>
-              {ROLES.map((r) => (
-                <div
-                  key={r}
-                  onClick={() => toggleRole(r)}
-                  className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide text-white/60"
-                >
-                  <div
-                    className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
-                      selectedRoles.includes(r)
-                        ? "bg-[#e8257a]/40 border-[#e8257a] text-white"
-                        : "border-white/20"
-                    }`}
-                  >
-                    {selectedRoles.includes(r) && "✓"}
-                  </div>
-                  <span
-                    className={selectedRoles.includes(r) ? "text-white" : ""}
-                  >
-                    {r}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        <MultiSelect
+          label="Player Type"
+          options={ROLES}
+          selected={selectedRoles}
+          onChange={setSelectedRoles}
+          allLabel="All Roles"
+        />
 
         {/* Divider */}
         <div className="w-px h-5 bg-white/10 mx-1.5 shrink-0" />
@@ -236,37 +123,74 @@ export function SearchFilterBar({
 
       {/* Active filter pills — always visible */}
       <div className="flex flex-wrap gap-2 mt-3 w-full">
-        {selectedCountries.length === 0 ? (
-          COUNTRIES.map((c) => (
+        {(selectedCountries.length === 0 ? COUNTRIES : selectedCountries).map((c) => {
+          const isSelected = selectedCountries.includes(c);
+          const isAllMode = selectedCountries.length === 0;
+          
+          return (
             <span
               key={c}
-              onClick={() => toggleCountry(c)}
-              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold tracking-wide px-3 py-1 cursor-pointer bg-zinc-800/60 text-zinc-500 border border-zinc-700/40 hover:text-zinc-300 hover:border-zinc-600 transition-colors"
+              onClick={() => isAllMode ? setSelectedCountries(COUNTRIES.filter(x => x !== c)) : toggleCountry(c)}
+              className={`inline-flex items-center gap-1.5 rounded-full text-xs font-bold tracking-wide px-3 py-1 cursor-pointer transition-colors ${
+                isAllMode || isSelected
+                  ? "bg-blue-900/50 text-blue-300 border border-blue-700/50"
+                  : "bg-zinc-800/60 text-zinc-500 border border-zinc-700/40 hover:text-zinc-300 hover:border-zinc-600"
+              }`}
             >
               {c}
+              {(isAllMode || isSelected) && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isAllMode) {
+                      setSelectedCountries(COUNTRIES.filter(x => x !== c));
+                    } else {
+                      removeCountry(c);
+                    }
+                  }}
+                  className="opacity-60 hover:opacity-100 text-[11px] leading-none"
+                >
+                  ✕
+                </button>
+              )}
             </span>
-          ))
-        ) : (
-          selectedCountries.map((c) => (
-            <span
-              key={c}
-              className="inline-flex items-center gap-1.5 rounded-full text-xs font-bold tracking-wide px-3 py-1 bg-blue-900/50 text-blue-300 border border-blue-700/50"
-            >
-              {c}
-              <button
-                onClick={() => removeCountry(c)}
-                className="opacity-60 hover:opacity-100 text-[11px] leading-none"
-              >
-                ✕
-              </button>
-            </span>
-          ))
-        )}
+          );
+        })}
 
         <div className="w-px h-4 self-center bg-white/10 mx-1 shrink-0" />
 
-        {selectedRoles.length === 0 ? (
-          ROLES.map((r) => (
+        {(selectedRoles.length === 0 ? ROLES : selectedRoles).map((r) => {
+          const isSelected = selectedRoles.includes(r);
+          const isAllMode = selectedRoles.length === 0;
+          const roleKey = r.toLowerCase() as "batter" | "bowler" | "allrounder" | "keeper";
+
+          if (isAllMode || isSelected) {
+            return (
+              <RoleBadge
+                key={r}
+                role={roleKey}
+                onClick={() => isAllMode ? setSelectedRoles(ROLES.filter(x => x !== r)) : toggleRole(r)}
+                className="cursor-pointer"
+              >
+                {r}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isAllMode) {
+                      setSelectedRoles(ROLES.filter(x => x !== r));
+                    } else {
+                      removeRole(r);
+                    }
+                  }}
+                  className="opacity-60 hover:opacity-100 text-[11px] leading-none"
+                >
+                  ✕
+                </button>
+              </RoleBadge>
+            );
+          }
+
+          return (
             <span
               key={r}
               onClick={() => toggleRole(r)}
@@ -274,23 +198,8 @@ export function SearchFilterBar({
             >
               {r}
             </span>
-          ))
-        ) : (
-          selectedRoles.map((r) => (
-            <RoleBadge
-              key={r}
-              role={r.toLowerCase() as "batter" | "bowler" | "allrounder" | "keeper"}
-            >
-              {r}
-              <button
-                onClick={() => removeRole(r)}
-                className="opacity-60 hover:opacity-100 text-[11px] leading-none"
-              >
-                ✕
-              </button>
-            </RoleBadge>
-          ))
-        )}
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/components/ui/MultiSelect.tsx
+++ b/apps/web/src/components/ui/MultiSelect.tsx
@@ -1,0 +1,131 @@
+import { useState, useRef, useEffect } from "react";
+
+interface MultiSelectProps {
+  label: string;
+  options: string[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  allLabel?: string;
+  badgeColor?: string;
+}
+
+export function MultiSelect({
+  label,
+  options,
+  selected,
+  onChange,
+  allLabel = "All",
+  badgeColor = "#e8257a",
+}: MultiSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const toggleOption = (option: string) => {
+    if (selected.includes(option)) {
+      onChange(selected.filter((item) => item !== option));
+    } else {
+      onChange([...selected, option]);
+    }
+  };
+
+  const handleSelectOnly = (e: React.MouseEvent, option: string) => {
+    e.stopPropagation();
+    onChange([option]);
+  };
+
+  const isAllSelected = selected.length === 0 || selected.length === options.length;
+
+  return (
+    <div className="relative shrink-0" ref={containerRef}>
+      <button
+        onClick={() => setIsOpen((o) => !o)}
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl font-bold text-[13px] tracking-wide text-white/55 hover:bg-white/5 transition-colors group"
+      >
+        <span className="group-hover:text-white/80 transition-colors">{label}</span>
+        {selected.length > 0 && (
+          <span 
+            className="text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 leading-none"
+            style={{ backgroundColor: badgeColor }}
+          >
+            {selected.length}
+          </span>
+        )}
+        <span className="text-[9px] opacity-40 transition-transform duration-200" style={{ transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}>
+          ▾
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-[calc(100%+8px)] left-0 bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 min-w-[200px] shadow-2xl animate-in fade-in zoom-in duration-150">
+          {/* Select All Option */}
+          <div
+            onClick={() => onChange([])}
+            className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide border-b border-white/5 mb-1 group"
+          >
+            <div
+              className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
+                selected.length === 0
+                  ? "border-transparent text-white"
+                  : "border-white/20"
+              }`}
+              style={{ backgroundColor: selected.length === 0 ? badgeColor : 'transparent' }}
+            >
+              {selected.length === 0 && "✓"}
+            </div>
+            <span className={selected.length === 0 ? "text-white" : "text-white/60 group-hover:text-white/80"}>
+              {allLabel}
+            </span>
+          </div>
+
+          {/* Individual Options */}
+          <div className="max-h-[280px] overflow-y-auto custom-scrollbar pr-1">
+            {options.map((option) => {
+              const isSelected = selected.includes(option);
+              return (
+                <div
+                  key={option}
+                  onClick={() => toggleOption(option)}
+                  className="flex items-center justify-between gap-2.5 px-3 py-2 rounded-lg cursor-pointer hover:bg-white/5 font-semibold text-[13px] tracking-wide text-white/60 group transition-colors"
+                >
+                  <div className="flex items-center gap-2.5 min-w-0 overflow-hidden">
+                    <div
+                      className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[9px] shrink-0 transition-all ${
+                        isSelected
+                          ? "border-transparent text-white"
+                          : "border-white/20"
+                      }`}
+                      style={{ backgroundColor: isSelected ? badgeColor : 'transparent' }}
+                    >
+                      {isSelected && "✓"}
+                    </div>
+                    <span className={`truncate ${isSelected ? "text-white" : "group-hover:text-white/80"}`}>
+                      {option}
+                    </span>
+                  </div>
+                  
+                  {/* Select Only Feature */}
+                  <button
+                    onClick={(e) => handleSelectOnly(e, option)}
+                    className="opacity-0 group-hover:opacity-100 px-1.5 py-0.5 rounded bg-white/10 hover:bg-white/20 text-[10px] text-white/70 hover:text-white transition-all shrink-0"
+                  >
+                    only
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/RoleBadge.tsx
+++ b/apps/web/src/components/ui/RoleBadge.tsx
@@ -22,11 +22,15 @@ interface RoleBadgeProps extends VariantProps<typeof roleBadge> {
   role: RoleKey;
   children?: ReactNode;
   className?: string;
+  onClick?: () => void;
 }
 
-export function RoleBadge({ role, children, className }: RoleBadgeProps) {
+export function RoleBadge({ role, children, className, onClick }: RoleBadgeProps) {
   return (
-    <span className={cn(roleBadge({ role }), className)}>
+    <span 
+      className={cn(roleBadge({ role }), className)}
+      onClick={onClick}
+    >
       {children ?? role}
     </span>
   );

--- a/apps/web/src/components/ui/Select.tsx
+++ b/apps/web/src/components/ui/Select.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+interface SelectProps {
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export function Select({
+  options,
+  value,
+  onChange,
+  placeholder = "Select an option...",
+  className,
+}: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  return (
+    <div className={cn("relative w-full", className)} ref={containerRef}>
+      <button
+        onClick={() => setIsOpen((o) => !o)}
+        className="w-full flex items-center justify-between bg-zinc-800 hover:bg-zinc-700/80 rounded-xl px-4 py-3 text-white transition-all border border-white/5 focus:outline-none focus:ring-2 focus:ring-pink-500/50 group"
+      >
+        <span className={cn("truncate", !value && "text-zinc-500")}>
+          {value || placeholder}
+        </span>
+        <span className={cn(
+          "text-[10px] opacity-40 transition-transform duration-200",
+          isOpen ? "rotate-180" : "rotate-0"
+        )}>
+          ▾
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-[calc(100%+8px)] left-0 w-full bg-zinc-900 border border-zinc-700 rounded-xl p-2 z-50 shadow-2xl animate-in fade-in zoom-in duration-150">
+          <div className="max-h-[200px] overflow-y-auto custom-scrollbar pr-1">
+            {options.map((option) => {
+              const isSelected = value === option;
+              return (
+                <div
+                  key={option}
+                  onClick={() => {
+                    onChange(option);
+                    setIsOpen(false);
+                  }}
+                  className={cn(
+                    "flex items-center justify-between px-3 py-2.5 rounded-lg cursor-pointer transition-colors font-semibold text-[13px] tracking-wide",
+                    isSelected 
+                      ? "bg-pink-500/10 text-pink-400" 
+                      : "text-white/60 hover:bg-white/5 hover:text-white"
+                  )}
+                >
+                  <span className="truncate">{option}</span>
+                  {isSelected && <span className="text-[10px]">✓</span>}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/TabSwitch.tsx
+++ b/apps/web/src/components/ui/TabSwitch.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+interface TabOption {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface TabSwitchProps {
+  options: TabOption[];
+  value: string;
+  onChange: (id: string) => void;
+  className?: string;
+}
+
+export function TabSwitch({ options, value, onChange, className }: TabSwitchProps) {
+  return (
+    <div 
+      className={cn(
+        "relative flex p-1 bg-white/[0.03] border border-white/10 rounded-2xl w-fit",
+        className
+      )}
+    >
+      {/* Sliding background pill */}
+      <motion.div
+        className="absolute inset-y-1 rounded-xl bg-white/10 border border-white/5 shadow-xl"
+        initial={false}
+        animate={{
+          x: options.findIndex((o) => o.id === value) * (100 / options.length) + "%",
+          width: 100 / options.length + "%",
+        }}
+        transition={{ type: "spring", bounce: 0.2, duration: 0.6 }}
+        style={{
+          width: `calc(${100 / options.length}% - 8px)`,
+          left: "4px",
+        }}
+      />
+
+      {options.map((option) => {
+        const isActive = value === option.id;
+        return (
+          <button
+            key={option.id}
+            onClick={() => onChange(option.id)}
+            className={cn(
+              "relative flex items-center justify-center gap-2 px-4 py-2 text-sm font-bold tracking-wide transition-colors z-10 min-w-[100px]",
+              isActive ? "text-white" : "text-white/40 hover:text-white/60"
+            )}
+          >
+            {option.icon && (
+              <span className={cn("transition-transform duration-200", isActive ? "scale-110" : "scale-100")}>
+                {option.icon}
+              </span>
+            )}
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -4,3 +4,6 @@ export { FormatPill } from "./FormatPill";
 export { RarityBadge } from "./RarityBadge";
 export { RoleBadge } from "./RoleBadge";
 export { SectionLabel } from "./SectionLabel";
+export { MultiSelect } from "./MultiSelect";
+export { TabSwitch } from "./TabSwitch";
+export { Select } from "./Select";


### PR DESCRIPTION
## New components

### `Select`
Single-value dropdown replacing the native `<select>` element. Click-outside dismiss, pink active state, smooth open/close animation. Used in the **card-builder Presets tab** for country selection.

### `MultiSelect`
Multi-value dropdown with:
- Active badge count on the trigger button
- "Select all" shortcut at the top of the list
- Per-option **"only"** shortcut (hover-revealed)
- Click-outside dismiss encapsulated inside the component

Used in **SearchFilterBar** for the Countries and Player Type filters.

### `TabSwitch`
Animated tab switcher using a Framer Motion spring-driven sliding pill. Supports optional icons per tab and arbitrary option count. **Exported from the barrel but not yet wired to a page** — ready for the card-builder tab strip or any future tabbed view.

---

## Refactors

### `SearchFilterBar` — ~120 lines removed
Both dropdown filter blocks (Countries, Player Type) were replaced with `MultiSelect`. All open/close state and `mousedown` listener boilerplate is now encapsulated in the component. Active filter pills unified into a single render path covering both "all selected" and "subset selected" modes.

### `RoleBadge`
Added an `onClick` prop so filter pills in SearchFilterBar can attach deselect handlers directly without a wrapper element.

### `players/page.tsx`
Narrowed the `search` param type — Next.js passes `string | string[]` from `searchParams`; added a string guard before passing to the filter.

---

## Checklist
- [ ] Countries MultiSelect opens/closes correctly, badge count updates
- [ ] Player Type MultiSelect works the same
- [ ] "only" shortcut on MultiSelect isolates a single option
- [ ] Select in card-builder Presets tab saves and applies country theme
- [ ] Active filter pills deselect correctly in both all-mode and subset-mode
- [ ] TabSwitch renders correctly if dropped into a page (visual check)