### PR TITLE
feat(ui): wire TabSwitch across card-builder and player detail

### DIFF
--- a/apps/web/src/app/card-builder/page.tsx
+++ b/apps/web/src/app/card-builder/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/card";
 import { useCountryTheme, useTitle } from "@/hooks";
 import { PageHeader } from "@/components/layout";
-import { SectionLabel, CardButton, Select } from "@/components/ui";
+import { SectionLabel, CardButton, Select, TabSwitch } from "@/components/ui";
 import {
   ROLE_SHOTS,
   DEFAULT_SHOT,
@@ -54,6 +54,54 @@ function getActiveKeys(
   }
   return ["cap", "capAccent", "shoes"];
 }
+
+const ROLE_OPTIONS = [
+  {
+    id: "batter" as const,
+    label: "Batter",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4 20L16 4" />
+        <path d="M16 4l4 4" />
+        <path d="M4 20l4-4" />
+      </svg>
+    ),
+  },
+  {
+    id: "bowler" as const,
+    label: "Bowler",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 3c2 4 2 14 0 18" />
+        <path d="M3 12c4-2 14-2 18 0" />
+      </svg>
+    ),
+  },
+  {
+    id: "allrounder" as const,
+    label: "All",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 17L9 5" />
+        <path d="M9 5l3 3" />
+        <circle cx="17" cy="15" r="4" />
+      </svg>
+    ),
+  },
+  {
+    id: "keeper" as const,
+    label: "Keeper",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 11V6a2 2 0 0 0-4 0v5" />
+        <path d="M14 10V4a2 2 0 0 0-4 0v6" />
+        <path d="M10 10.5V6a2 2 0 0 0-4 0v8" />
+        <path d="M6 14a4 4 0 0 0 4 4h4a4 4 0 0 0 4-4v-2.5" />
+      </svg>
+    ),
+  },
+];
 
 interface ColorFieldProps {
   label: string;
@@ -109,6 +157,67 @@ function ColorField({ label, value, onChange, tabIndex }: ColorFieldProps) {
     </div>
   );
 }
+
+const MODE_OPTIONS = [
+  {
+    id: "form" as const,
+    label: "Form",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <line x1="8" y1="6" x2="21" y2="6" />
+        <line x1="8" y1="12" x2="21" y2="12" />
+        <line x1="8" y1="18" x2="21" y2="18" />
+        <line x1="3" y1="6" x2="3.01" y2="6" />
+        <line x1="3" y1="12" x2="3.01" y2="12" />
+        <line x1="3" y1="18" x2="3.01" y2="18" />
+      </svg>
+    ),
+  },
+  {
+    id: "tap" as const,
+    label: "Tap",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M9 11V6a2 2 0 0 1 4 0v5" />
+        <path d="M13 11V8a2 2 0 0 1 4 0v5" />
+        <path d="M17 11V9.5a2 2 0 0 1 4 0V17a4 4 0 0 1-4 4h-3a4 4 0 0 1-3.16-1.53L5 12a2 2 0 0 1 2.72-2.93L9 11" />
+      </svg>
+    ),
+  },
+];
+
+const TAB_OPTIONS = [
+  {
+    id: "card" as const,
+    label: "Card",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <line x1="3" y1="9" x2="21" y2="9" />
+      </svg>
+    ),
+  },
+  {
+    id: "character" as const,
+    label: "Character",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="8" r="4" />
+        <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+      </svg>
+    ),
+  },
+  {
+    id: "presets" as const,
+    label: "Presets",
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M12 2v3M12 19v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M2 12h3M19 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12" />
+      </svg>
+    ),
+  },
+];
 
 function CardBuilderPageInner() {
   const searchParams = useSearchParams();
@@ -175,16 +284,13 @@ function CardBuilderPageInner() {
           </>
         }
         right={
-          <button
-            onClick={() => setEditMode((m) => (m === "form" ? "tap" : "form"))}
-            className={`px-4 py-1.5 rounded-full text-sm font-bold tracking-widest transition-all ${
-              editMode === "tap"
-                ? "bg-pink-500 text-white"
-                : "border border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
-            }`}
-          >
-            {editMode === "tap" ? "Tap Mode" : "Form Mode"}
-          </button>
+          <div className="h-12 w-[120px] overflow-visible">
+            <TabSwitch
+              options={MODE_OPTIONS}
+              value={editMode}
+              onChange={(v) => setEditMode(v as "form" | "tap")}
+            />
+          </div>
         }
       />
 
@@ -215,22 +321,14 @@ function CardBuilderPageInner() {
 
         {/* Right — Form Panel (hidden in tap mode) */}
         {editMode === "form" && (
-          <div className="flex-1 max-w-md flex flex-col gap-4">
+          <div className="flex-1 min-w-0 max-w-md flex flex-col gap-4">
             {/* Tabs */}
-            <div className="flex gap-1 bg-zinc-900 rounded-2xl p-1">
-              {(["card", "character", "presets"] as const).map((tab) => (
-                <button
-                  key={tab}
-                  onClick={() => setActiveTab(tab)}
-                  className={`flex-1 py-2 rounded-xl text-xs tracking-widest font-bold transition-all ${
-                    activeTab === tab
-                      ? "bg-pink-500 text-white"
-                      : "text-zinc-400 hover:text-zinc-200"
-                  }`}
-                >
-                  {tab}
-                </button>
-              ))}
+            <div className="h-12 w-full overflow-visible">
+              <TabSwitch
+                options={TAB_OPTIONS}
+                value={activeTab}
+                onChange={(v) => setActiveTab(v as "card" | "character" | "presets")}
+              />
             </div>
 
             {/* Tab: Card */}
@@ -268,41 +366,26 @@ function CardBuilderPageInner() {
               <div className="flex flex-col gap-4">
                 {/* Role selector */}
                 <SectionLabel>Role</SectionLabel>
-                <div className="grid grid-cols-4 gap-2">
-                  {(
-                    ["batter", "bowler", "allrounder", "keeper"] as PlayerRole[]
-                  ).map((role, i) => (
-                    <button
-                      key={role}
-                      tabIndex={5 + i}
-                      onClick={() => handleRoleChange(role)}
-                      className={`py-2 rounded-xl text-xs tracking-widest font-bold transition-all ${
-                        selectedRole === role
-                          ? "bg-pink-500 text-white"
-                          : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
-                      }`}
-                    >
-                      {role}
-                    </button>
-                  ))}
+                <div className="h-12 w-full overflow-visible">
+                  <TabSwitch
+                    options={ROLE_OPTIONS}
+                    value={selectedRole}
+                    onChange={(v) => handleRoleChange(v as PlayerRole)}
+                  />
                 </div>
 
                 {/* Shot selector */}
                 <SectionLabel className="mt-2">Shot</SectionLabel>
-                <div className="grid grid-cols-3 gap-2">
-                  {ROLE_SHOTS[selectedRole].map((shot) => (
-                    <button
-                      key={shot}
-                      onClick={() => setSelectedShot(shot)}
-                      className={`py-2 rounded-xl text-xs tracking-widest font-bold transition-all ${
-                        selectedShot === shot
-                          ? "bg-yellow-400 text-zinc-900"
-                          : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700"
-                      }`}
-                    >
-                      {shot}
-                    </button>
-                  ))}
+                <div className="h-12 w-full overflow-visible">
+                  <TabSwitch
+                    options={ROLE_SHOTS[selectedRole].map((shot) => ({
+                      id: shot,
+                      label: shot,
+                    }))}
+                    value={selectedShot}
+                    onChange={(v) => setSelectedShot(v as ShotType)}
+                    ballColor="#facc15"
+                  />
                 </div>
 
                 {/* Character color fields */}

--- a/apps/web/src/app/players/[id]/ViewSwitcher.tsx
+++ b/apps/web/src/app/players/[id]/ViewSwitcher.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { TabSwitch } from "@/components/ui";
+
+const CARD_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <line x1="3" y1="9" x2="21" y2="9" />
+    <line x1="9" y1="21" x2="9" y2="9" />
+  </svg>
+);
+
+const TABLE_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 3h18v18H3z" />
+    <path d="M3 9h18" />
+    <path d="M3 15h18" />
+    <path d="M9 3v18" />
+  </svg>
+);
+
+interface ViewSwitcherProps {
+  playerId: string;
+  view: string;
+}
+
+export function ViewSwitcher({ playerId, view }: ViewSwitcherProps) {
+  const router = useRouter();
+  return (
+    <div className="h-12 w-[120px] overflow-visible">
+      <TabSwitch
+        options={[
+          { id: "card", label: "Card", icon: CARD_ICON },
+          { id: "table", label: "Table", icon: TABLE_ICON },
+        ]}
+        value={view}
+        onChange={(v) =>
+          router.push(`/players/${playerId}?view=${v}`, { scroll: false })
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -7,6 +7,7 @@ import { CardScaleWrapper } from "@/components/card/CardScaleWrapper";
 import { PageHeader } from "@/components/layout";
 import { StatsGrid } from "@/components/card/StatsGrid";
 import StatCard from "@/components/card/StatCard";
+import { ViewSwitcher } from "./ViewSwitcher";
 import {
   CARD_WIDTH,
   CARD_HEIGHT,
@@ -16,8 +17,6 @@ import {
 
 type Params = Promise<{ id: string }>;
 type SearchParams = Promise<{ view?: string }>;
-
-// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default async function PlayerDetailPage({
   params,
@@ -43,11 +42,8 @@ export default async function PlayerDetailPage({
 
   const { player, stats } = result.data;
   const odiStats = stats.odi;
-  const playerStats = playerToStatCard(
-    result.data,
-    player.external_id,
-    "Legend"
-  );
+  const playerStats = playerToStatCard(result.data, player.external_id, "Legend");
+
   return (
     <div className="bg-zinc-950 min-h-screen">
       <PageHeader
@@ -57,36 +53,16 @@ export default async function PlayerDetailPage({
             <span className="font-display text-md tracking-widest text-white">
               {player.country}
             </span>
-            <span className="mx-2 flex-shrink-0 text-pink-400 font-bold">
-              ›
-            </span>
+            <span className="mx-2 flex-shrink-0 text-pink-400 font-bold">›</span>
             <span className="font-display text-md tracking-widest text-white">
               {player.role}
             </span>
           </>
         }
-        right={
-          <div className="flex gap-1 bg-zinc-900 rounded-full p-1">
-            {(["card", "table"] as const).map((v) => (
-              <Link
-                key={v}
-                href={`/players/${player.id}?view=${v}`}
-                className={`px-4 py-1.5 rounded-full text-xs font-bold tracking-widest transition-all ${
-                  view === v
-                    ? "bg-zinc-100 text-zinc-950"
-                    : "text-zinc-400 hover:text-zinc-200"
-                }`}
-              >
-                {v === "card" ? "Card View" : "Table View"}
-              </Link>
-            ))}
-          </div>
-        }
+        right={<ViewSwitcher playerId={player.id} view={view} />}
       />
 
       <div className="px-8 py-4">
-
-        {/* Content */}
         {view === "card" ? (
           <div className="flex flex-wrap gap-8 justify-center">
             <div className="flex flex-col items-center gap-3">
@@ -122,12 +98,7 @@ export default async function PlayerDetailPage({
                 Brand Card ↗
               </p>
               <CardScaleWrapper scale="detail">
-                <CricketCard
-                  player={player}
-                  stats={odiStats}
-                  variant="brand"
-                  noLink
-                />
+                <CricketCard player={player} stats={odiStats} variant="brand" noLink />
               </CardScaleWrapper>
             </Link>
           </div>

--- a/apps/web/src/components/ui/TabSwitch.tsx
+++ b/apps/web/src/components/ui/TabSwitch.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef, useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
@@ -14,48 +15,105 @@ interface TabSwitchProps {
   value: string;
   onChange: (id: string) => void;
   className?: string;
+  ballColor?: string;
 }
 
-export function TabSwitch({ options, value, onChange, className }: TabSwitchProps) {
-  return (
-    <div 
-      className={cn(
-        "relative flex p-1 bg-white/[0.03] border border-white/10 rounded-2xl w-fit",
-        className
-      )}
-    >
-      {/* Sliding background pill */}
-      <motion.div
-        className="absolute inset-y-1 rounded-xl bg-white/10 border border-white/5 shadow-xl"
-        initial={false}
-        animate={{
-          x: options.findIndex((o) => o.id === value) * (100 / options.length) + "%",
-          width: 100 / options.length + "%",
-        }}
-        transition={{ type: "spring", bounce: 0.2, duration: 0.6 }}
-        style={{
-          width: `calc(${100 / options.length}% - 8px)`,
-          left: "4px",
-        }}
-      />
+export function TabSwitch({
+  options,
+  value,
+  onChange,
+  className,
+  ballColor = "#e8257a",
+}: TabSwitchProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
 
-      {options.map((option) => {
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setContainerWidth(el.offsetWidth);
+    const observer = new ResizeObserver(() =>
+      setContainerWidth(el.offsetWidth)
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const activeIndex = options.findIndex((o) => o.id === value);
+  const step = 100 / options.length;
+  const slotWidth = containerWidth / options.length;
+  const activeX = (activeIndex + 0.5) * slotWidth;
+
+  return (
+    <div ref={containerRef} className={cn("relative h-full w-full", className)}>
+      {/* The Main Bar — fills container minus ball radius at top */}
+      <div
+        className="absolute left-0 right-0 bottom-0 bg-zinc-900 border border-white/5 rounded-xl shadow-2xl"
+        style={{ height: "calc(100% - 18px)" }}
+      >
+        {/* The Sliding Curved Cutout (SVG Mask) */}
+        <motion.div
+          className="absolute top-0 h-full flex items-start justify-center pointer-events-none"
+          initial={false}
+          animate={{ x: `${activeIndex * step}%`, width: `${step}%` }}
+          transition={{ type: "spring", bounce: 0.15, duration: 0.6 }}
+        >
+          {/*
+            This SVG creates the "Dip" effect.
+            It is filled with the background color of the page (zinc-950).
+          */}
+          <svg
+            viewBox="0 0 100 40"
+            className="w-full h-full -mt-[0.5px] fill-zinc-950"
+            preserveAspectRatio="none"
+          >
+            <path d="M0 0 Q10 0 15 2 Q25 10 30 25 A20 20 0 0 0 70 25 Q75 10 85 2 Q90 0 100 0 V40 H0 Z" />
+          </svg>
+        </motion.div>
+      </div>
+
+      {/* The Floating Active Circle — centred on the bar's top edge */}
+      <motion.div
+        className="absolute h-10 w-10 rounded-full border-[3px] border-zinc-950 z-20 flex items-center justify-center text-white"
+        style={{
+          bottom: "calc(100% - 36px)",
+          backgroundColor: ballColor,
+          boxShadow: `0 8px 20px -4px ${ballColor}99`,
+        }}
+        initial={false}
+        animate={{ x: activeX - 20 }}
+        transition={{ type: "spring", bounce: 0.25, duration: 0.6 }}
+      >
+        <div className="scale-90">{options[activeIndex]?.icon}</div>
+      </motion.div>
+
+      {/* The Tab Buttons — absolutely positioned over the bar */}
+      {options.map((option, index) => {
         const isActive = value === option.id;
         return (
           <button
             key={option.id}
             onClick={() => onChange(option.id)}
             className={cn(
-              "relative flex items-center justify-center gap-2 px-4 py-2 text-sm font-bold tracking-wide transition-colors z-10 min-w-[100px]",
-              isActive ? "text-white" : "text-white/40 hover:text-white/60"
+              "absolute bottom-0 flex flex-col items-center justify-end z-10",
+              isActive ? "pb-0.5" : "pb-1.5"
             )}
+            style={{
+              left: `${(index / options.length) * 100}%`,
+              width: `${100 / options.length}%`,
+              height: "calc(100% - 18px)",
+            }}
           >
-            {option.icon && (
-              <span className={cn("transition-transform duration-200", isActive ? "scale-110" : "scale-100")}>
-                {option.icon}
-              </span>
-            )}
-            <span>{option.label}</span>
+            <span
+              className={cn(
+                "font-bold tracking-widest",
+                isActive
+                  ? "text-[7px] text-white/80"
+                  : "text-[12px] text-white/80"
+              )}
+            >
+              {option.label}
+            </span>
           </button>
         );
       })}


### PR DESCRIPTION
## Summary

- Add `ballColor` prop to `TabSwitch` so each usage can independently theme the active ball (defaults to pink `#e8257a`)
- Replace card-builder's tab strip, edit-mode toggle, role selector, and shot selector with `TabSwitch`; shot selector uses yellow `#facc15` ball
- Extract `ViewSwitcher` as a co-located client component on the player detail page, keeping the server page intact while enabling router-driven `TabSwitch` for card/table view switching

## Test plan

- [ ] Card builder — confirm all four tabs animate correctly (Card / Character / Presets)
- [ ] Card builder — Form/Tap mode toggle works and hides/shows the form panel
- [ ] Card builder — Role selector cycles through Batter / Bowler / All / Keeper
- [ ] Card builder — Shot selector shows yellow ball, options update when role changes
- [ ] Player detail — card/table view switcher still toggles correctly via URL param
- [ ] `npm run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)