### PR TITLE
feat(nav): back navigation and stat card → table link

### DIFF
--- a/apps/web/src/app/card-builder/page.tsx
+++ b/apps/web/src/app/card-builder/page.tsx
@@ -304,6 +304,8 @@ function CardBuilderPageInner() {
   const searchParams = useSearchParams();
   const countryParam = searchParams.get("country");
   const roleParam = searchParams.get("role") as PlayerRole | null;
+  const fromParam = searchParams.get("from");
+  const fromLabelParam = searchParams.get("fromLabel");
 
   const [selectedCountry, setSelectedCountry] = useState(
     countryParam ?? "India"
@@ -354,6 +356,11 @@ function CardBuilderPageInner() {
     <main className="min-h-screen bg-zinc-950 text-white flex flex-col">
       <PageHeader
         title="Card Builder"
+        back={
+          fromParam != null
+            ? { label: fromLabelParam ?? "Back" }
+            : undefined
+        }
         subtitle={
           <>
             <span className="font-display text-md tracking-widest text-white flex-shrink-0">

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -65,9 +65,13 @@ export default async function PlayerDetailPage({
       <div className="px-8 py-4">
         {view === "card" ? (
           <div className="flex flex-wrap gap-8 justify-center">
-            <div className="flex flex-col items-center gap-3">
-              <p className="text-zinc-600 text-[10px] tracking-widest font-mono">
-                Stat Card
+            <Link
+              href={`/players/${player.id}?view=table`}
+              scroll={false}
+              className="flex flex-col items-center gap-3 group cursor-pointer"
+            >
+              <p className="text-zinc-600 text-[10px] tracking-widest font-mono group-hover:text-pink-400 transition-colors">
+                Stat Card ↗
               </p>
               <div
                 style={{
@@ -89,7 +93,7 @@ export default async function PlayerDetailPage({
                   <StatCard stats={playerStats} />
                 </div>
               </div>
-            </div>
+            </Link>
             <Link
               href={`/card-builder?country=${encodeURIComponent(player.country)}&role=${player.role}`}
               className="flex flex-col items-center gap-3 group cursor-pointer"

--- a/apps/web/src/app/players/[id]/page.tsx
+++ b/apps/web/src/app/players/[id]/page.tsx
@@ -48,6 +48,7 @@ export default async function PlayerDetailPage({
     <div className="bg-zinc-950 min-h-screen">
       <PageHeader
         title={player.name}
+        back={{ label: "Players" }}
         subtitle={
           <>
             <span className="font-display text-md tracking-widest text-white">
@@ -95,7 +96,7 @@ export default async function PlayerDetailPage({
               </div>
             </Link>
             <Link
-              href={`/card-builder?country=${encodeURIComponent(player.country)}&role=${player.role}`}
+              href={`/card-builder?country=${encodeURIComponent(player.country)}&role=${player.role}&from=${encodeURIComponent(`/players/${player.id}`)}&fromLabel=${encodeURIComponent(player.name)}`}
               className="flex flex-col items-center gap-3 group cursor-pointer"
             >
               <p className="text-zinc-600 text-[10px] tracking-widest font-mono group-hover:text-pink-400 transition-colors">

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ReactNode } from "react";
+import { useRouter } from "next/navigation";
 import { usePageHeaderContent } from "@/hooks/usePageHeaderContent";
 
 interface PageHeaderProps {
@@ -8,6 +9,7 @@ interface PageHeaderProps {
   subtitle?: ReactNode;
   subtitleFill?: boolean;
   right?: ReactNode;
+  back?: { label: string };
 }
 
 export function PageHeader({
@@ -15,9 +17,26 @@ export function PageHeader({
   subtitle,
   subtitleFill = false,
   right,
+  back,
 }: PageHeaderProps) {
+  const router = useRouter();
+
   usePageHeaderContent(
     <div className="flex items-center w-full">
+      {back != null && (
+        <>
+          <button
+            onClick={() => router.back()}
+            className="group flex items-center gap-1.5 font-display text-md tracking-widest flex-shrink-0 text-zinc-400 hover:text-pink-400 transition-colors cursor-pointer"
+          >
+            <span className="text-zinc-600 group-hover:text-pink-400 transition-colors text-lg leading-none">
+              ←
+            </span>
+            {back.label}
+          </button>
+          <span className="mx-2 flex-shrink-0 text-pink-400 font-bold">›</span>
+        </>
+      )}
       <span className="font-display text-md tracking-widest flex-shrink-0">
         {title}
       </span>


### PR DESCRIPTION
## Summary

- **Stat card → table link**: clicking the Stat Card on the player detail page navigates to `?view=table`, matching the Brand Card → card-builder pattern
- **Back navigation**: `PageHeader` now accepts a `back` prop that renders a `← Label` button using `router.back()`
  - Player detail page: `← Players` restores scroll position on the players list natively (no sessionStorage needed)
  - Card builder: `← {player name}` appears when navigated from a player detail page, takes the user back
- **Visual affordance**: back button uses a `←` arrow with pink hover state to make it clearly interactive

## Test plan

- [ ] Players list → click player → player detail shows `← Players` in header
- [ ] Click `← Players` → lands back on players list at the same scroll position
- [ ] Player detail → click Brand Card → card builder shows `← {player name}` in header
- [ ] Click `← {player name}` in card builder → returns to player detail page
- [ ] Card builder accessed directly (no `from` param) → no back link shown
- [ ] Stat Card on player detail is a clickable link → navigates to `?view=table`
- [ ] No TypeScript errors (`npm run type-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)