### PR TITLE
chore: temporarily disable admin passphrase gate for card builder

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -19,7 +19,10 @@ export async function middleware(request: NextRequest) {
 
   // Admin routes use cookie-based auth, independent of Supabase
   if (pathname.startsWith('/admin')) {
-    if (pathname !== '/admin/login') {
+    // TODO: re-enable admin passphrase gate before public launch
+    const isCardBuilder = pathname.startsWith('/admin/card-builder')
+
+    if (pathname !== '/admin/login' && !isCardBuilder) {
       const token = request.cookies.get(ADMIN_COOKIE_NAME)?.value
       const secret = process.env.ADMIN_COOKIE_SECRET ?? ''
       const valid = token ? await verifyAdminToken(token, secret) : false


### PR DESCRIPTION
## Summary
- Bypasses the admin passphrase/cookie auth gate specifically for `/admin/card-builder` routes in `middleware.ts`, so the card builder is directly reachable in production without entering a passphrase.
- All other `/admin` routes (e.g. the review queue) keep their existing cookie-based auth check unchanged.
- Left a `// TODO: re-enable admin passphrase gate before public launch` marker at the bypass point.

## Test plan
- [x] `npm run type-check` passes
- [x] Verified locally: `/admin/card-builder/customize` returns `200` with no redirect (gate bypassed)
- [x] Verified other `/admin` routes retain original auth-check code path (unrelated local 500 due to missing Supabase env vars, confirmed pre-existing on `main` via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)